### PR TITLE
[JLLGenerator] add license information

### DIFF
--- a/JLLGenerator.jl/Manifest.toml
+++ b/JLLGenerator.jl/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.10.4"
 manifest_format = "2.0"
-project_hash = "296f94d033ecf898b2fab82b83f0756b5bc39867"
+project_hash = "cadc07c83331eb2ee8b4a577db9801e4d59df27f"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
@@ -49,6 +49,12 @@ uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
+[[deps.JLLWrappers]]
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "7e5d6779a1e09a36db2a7b6cff50942a0a7d0fca"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.5.0"
+
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
 uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
@@ -75,6 +81,12 @@ version = "1.11.0+1"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[deps.LicenseCheck]]
+deps = ["licensecheck_jll"]
+git-tree-sha1 = "e98bc9e1f773123cfdb1fa3d7a4c898e1f030341"
+uuid = "726dbf0d-6eb6-41af-b36c-cd770e0f00cc"
+version = "0.2.2"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -111,6 +123,12 @@ version = "1.6.3"
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 version = "1.10.0"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.4.3"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -166,6 +184,12 @@ uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
 version = "1.2.13+1"
+
+[[deps.licensecheck_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "b790ad21ac235c39c0eb34214ccf3d5f5ea60efa"
+uuid = "4ecb348a-8b88-51ea-b912-4c460483ee91"
+version = "0.3.101+0"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]

--- a/JLLGenerator.jl/Project.toml
+++ b/JLLGenerator.jl/Project.toml
@@ -5,7 +5,9 @@ version = "0.3.0"
 
 [deps]
 BinaryBuilderPlatformExtensions = "213f2928-4d72-6f46-7461-4c705f634367"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+LicenseCheck = "726dbf0d-6eb6-41af-b36c-cd770e0f00cc"
 MultiHashParsing = "73786568-6863-756d-6873-6168796e616d"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
@@ -20,13 +22,16 @@ BinaryBuilderSources = "316c416d-4527-6863-7465-466137743047"
 BinaryBuilderSourcesExt = "BinaryBuilderSources"
 
 [compat]
+BinaryBuilderPlatformExtensions = "0.1"
+LicenseCheck = "0.2"
+MultiHashParsing = "0.1"
 Reexport = "1"
 StructEquality = "2"
 julia = "1.9"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 BinaryBuilderSources = "316c416d-4527-6863-7465-466137743047"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "BinaryBuilderSources"]

--- a/JLLGenerator.jl/contrib/example_jllinfos/HelloWorldC_jll.jl
+++ b/JLLGenerator.jl/contrib/example_jllinfos/HelloWorldC_jll.jl
@@ -1,3 +1,5 @@
+hwc_license = JLLBuildLicense("LICENSE.md", JLLGenerator.get_license_text("MIT"))
+
 jll = JLLInfo(;
     name = "HelloWorldC",
     version = v"1.3.0+0",
@@ -27,7 +29,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -55,7 +58,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -83,7 +87,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -111,7 +116,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -139,7 +145,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -167,7 +174,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -195,7 +203,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -223,7 +232,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -251,7 +261,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -279,7 +290,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin\\hello_world.exe",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -307,7 +319,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -335,7 +348,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -363,7 +377,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -391,7 +406,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -419,7 +435,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -447,7 +464,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin\\hello_world.exe",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/example_jllinfos/Ncurses_jll.jl
+++ b/JLLGenerator.jl/contrib/example_jllinfos/Ncurses_jll.jl
@@ -15,6 +15,38 @@ if Sys.isunix()
 end
 """
 
+ncurses_license = JLLBuildLicense("LICENSE.md", """
+Copyright 2018-2023,2024 Thomas E. Dickey
+Copyright 1998-2017,2018 Free Software Foundation, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, distribute with modifications, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE ABOVE COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
+THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Except as contained in this notice, the name(s) of the above copyright
+holders shall not be used in advertising or otherwise to promote the
+sale, use or other dealings in this Software without prior written
+authorization.
+
+-- vile:txtmode fc=72
+-- \$Id: COPYING,v 1.13 2024/01/05 21:13:17 tom Exp \$
+""")
+
 jll = JLLInfo(;
     name = "Ncurses",
     version = v"6.4.1+0",
@@ -70,6 +102,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = ncurses_init,
+            licenses = [ncurses_license],
         ),
 
         JLLBuildInfo(;
@@ -123,6 +156,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = ncurses_init,
+            licenses = [ncurses_license],
         ),
 
         JLLBuildInfo(;
@@ -176,6 +210,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = ncurses_init,
+            licenses = [ncurses_license],
         ),
 
         JLLBuildInfo(;
@@ -229,6 +264,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = ncurses_init,
+            licenses = [ncurses_license],
         ),
 
         JLLBuildInfo(;
@@ -282,6 +318,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = ncurses_init,
+            licenses = [ncurses_license],
         ),
 
         JLLBuildInfo(;
@@ -335,6 +372,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = ncurses_init,
+            licenses = [ncurses_license],
         ),
 
         JLLBuildInfo(;
@@ -388,6 +426,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = ncurses_init,
+            licenses = [ncurses_license],
         ),
 
         JLLBuildInfo(;
@@ -441,6 +480,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = ncurses_init,
+            licenses = [ncurses_license],
         ),
 
         JLLBuildInfo(;
@@ -494,6 +534,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = ncurses_init,
+            licenses = [ncurses_license],
         ),
 
         JLLBuildInfo(;
@@ -547,6 +588,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = ncurses_init,
+            licenses = [ncurses_license],
         ),
 
         JLLBuildInfo(;
@@ -600,6 +642,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = ncurses_init,
+            licenses = [ncurses_license],
         ),
 
         JLLBuildInfo(;
@@ -653,6 +696,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = ncurses_init,
+            licenses = [ncurses_license],
         ),
 
         JLLBuildInfo(;
@@ -706,6 +750,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = ncurses_init,
+            licenses = [ncurses_license],
         ),
 
         JLLBuildInfo(;
@@ -759,6 +804,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = ncurses_init,
+            licenses = [ncurses_license],
         ),
 
         JLLBuildInfo(;
@@ -812,6 +858,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = ncurses_init,
+            licenses = [ncurses_license],
         ),
 
         JLLBuildInfo(;
@@ -865,6 +912,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = ncurses_init,
+            licenses = [ncurses_license],
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/example_jllinfos/PlatformAugmentedHelloWorldC_jll.jl
+++ b/JLLGenerator.jl/contrib/example_jllinfos/PlatformAugmentedHelloWorldC_jll.jl
@@ -1,3 +1,5 @@
+hwc_license = JLLBuildLicense("LICENSE.md", JLLGenerator.get_license_text("MIT"))
+
 jll = JLLInfo(;
     name = "PlatformAugmentedHelloWorldC",
     version = v"1.3.0+0",
@@ -33,7 +35,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -61,7 +64,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -89,7 +93,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -117,7 +122,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -145,7 +151,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -173,7 +180,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -201,7 +209,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -229,7 +238,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -257,7 +267,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -285,7 +296,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin\\hello_world.exe",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -313,7 +325,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -341,7 +354,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -369,7 +383,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -397,7 +412,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -425,7 +441,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin/hello_world",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
         JLLBuildInfo(;
@@ -453,7 +470,8 @@ jll = JLLInfo(;
                     :hello_world_doppelganger,
                     "bin\\hello_world.exe",
                 ),
-            ]
+            ],
+            licenses = [hwc_license],
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/example_jllinfos/Vulkan_Headers_jll.jl
+++ b/JLLGenerator.jl/contrib/example_jllinfos/Vulkan_Headers_jll.jl
@@ -1,3 +1,5 @@
+vulkan_headers_license = JLLBuildLicense("LICENSE.md", JLLGenerator.get_license_text("Apache-2.0"))
+
 jll = JLLInfo(;
     name = "Vulkan_Headers",
     version = v"1.3.243+1",
@@ -27,7 +29,8 @@ jll = JLLInfo(;
                     :vulkan_hpp,
                     "include/vulkan/vulkan.hpp",
                 ),
-            ]
+            ],
+            licenses = [vulkan_headers_license],
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/example_jllinfos/libxls_jll.jl
+++ b/JLLGenerator.jl/contrib/example_jllinfos/libxls_jll.jl
@@ -1,3 +1,36 @@
+libxls_license = JLLBuildLicense("LICENSE.md", """
+libxls -- A multiplatform, C/C++ library for parsing Excel(TM) files.
+
+Copyright 2004 Komarov Valery
+Copyright 2006 Christophe Leitienne
+Copyright 2008-2017 David Hoerl
+Copyright 2013 Bob Colbert
+Copyright 2013-2018 Evan Miller
+
+The included libxls code is licensed under the BSD 2-clause license:
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ''AS IS''
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+""")
+
 jll = JLLInfo(;
     name = "libxls",
     version = v"1.6.2+0",
@@ -25,7 +58,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libxls_license],
         ),
 
         JLLBuildInfo(;
@@ -51,7 +85,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libxls_license],
         ),
 
         JLLBuildInfo(;
@@ -77,7 +112,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libxls_license],
         ),
 
         JLLBuildInfo(;
@@ -103,7 +139,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libxls_license],
         ),
 
         JLLBuildInfo(;
@@ -129,7 +166,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libxls_license],
         ),
 
         JLLBuildInfo(;
@@ -155,7 +193,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libxls_license],
         ),
 
         JLLBuildInfo(;
@@ -181,7 +220,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libxls_license],
         ),
 
         JLLBuildInfo(;
@@ -207,7 +247,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libxls_license],
         ),
 
         JLLBuildInfo(;
@@ -233,7 +274,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libxls_license],
         ),
 
         JLLBuildInfo(;
@@ -259,7 +301,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libxls_license],
         ),
 
         JLLBuildInfo(;
@@ -285,7 +328,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libxls_license],
         ),
 
         JLLBuildInfo(;
@@ -311,7 +355,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libxls_license],
         ),
 
         JLLBuildInfo(;
@@ -337,7 +382,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libxls_license],
         ),
 
         JLLBuildInfo(;
@@ -363,7 +409,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libxls_license],
         ),
 
         JLLBuildInfo(;
@@ -389,7 +436,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libxls_license],
         ),
 
         JLLBuildInfo(;
@@ -415,7 +463,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libxls_license],
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/gen_julia_jlls.jl
+++ b/JLLGenerator.jl/contrib/gen_julia_jlls.jl
@@ -7,6 +7,10 @@ rm(out_dir; force=true, recursive=true)
 ENV["JULIA_PKG_PRECOMPILE_AUTO"] = "false"
 
 for file in readdir(joinpath(@__DIR__, "stdlib_jllinfos"); join=true)
+    if !endswith(file, "_jll.jl")
+        continue
+    end
+
     m = Module()
     Core.eval(m, :(using JLLGenerator))
     Core.include(m, file)

--- a/JLLGenerator.jl/contrib/jll_auto_upgrade_helper.jl
+++ b/JLLGenerator.jl/contrib/jll_auto_upgrade_helper.jl
@@ -146,7 +146,9 @@ function print_artifact_info(entry, platform, version, name)
     end
 
     println("""
-                ]
+                ],
+                # Note, you should replace this with the actual license
+                licenses = [JLLBuildLicense("LICENSE.md", JLLGenerator.get_license_text("MIT"))],
             ),
     """)
 end

--- a/JLLGenerator.jl/contrib/stdlib_jllinfos/CompilerSupportLibraries_jll.jl
+++ b/JLLGenerator.jl/contrib/stdlib_jllinfos/CompilerSupportLibraries_jll.jl
@@ -1,3 +1,5 @@
+csl_license = JLLBuildLicense("LICENSE.md", JLLGenerator.get_license_text("GPL-3.0"))
+
 jll = JLLInfo(;
     name = "CompilerSupportLibraries",
     version = v"1.0.5+1",
@@ -65,7 +67,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -125,7 +128,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -191,7 +195,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -257,7 +262,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -311,7 +317,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -371,7 +378,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -431,7 +439,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -497,7 +506,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -563,7 +573,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -629,7 +640,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -689,7 +701,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -749,7 +762,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -809,7 +823,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -875,7 +890,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -941,7 +957,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -1007,7 +1024,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -1067,7 +1085,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -1127,7 +1146,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -1187,7 +1207,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -1253,7 +1274,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -1319,7 +1341,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -1385,7 +1408,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -1445,7 +1469,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -1505,7 +1530,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -1565,7 +1591,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -1641,7 +1668,8 @@ jll = JLLInfo(;
                     :libssp_dll_a,
                     "lib\\libssp.dll.a",
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -1723,7 +1751,8 @@ jll = JLLInfo(;
                     :libssp_dll_a,
                     "lib\\libssp.dll.a",
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -1805,7 +1834,8 @@ jll = JLLInfo(;
                     :libssp_dll_a,
                     "lib\\libssp.dll.a",
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -1871,7 +1901,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -1937,7 +1968,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -2003,7 +2035,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -2069,7 +2102,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -2135,7 +2169,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -2201,7 +2236,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -2267,7 +2303,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -2333,7 +2370,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -2399,7 +2437,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -2459,7 +2498,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -2519,7 +2559,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -2579,7 +2620,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -2645,7 +2687,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -2711,7 +2754,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -2777,7 +2821,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -2853,7 +2898,8 @@ jll = JLLInfo(;
                     :libssp_dll_a,
                     "lib\\libssp.dll.a",
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -2935,7 +2981,8 @@ jll = JLLInfo(;
                     :libssp_dll_a,
                     "lib\\libssp.dll.a",
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
         JLLBuildInfo(;
@@ -3017,7 +3064,8 @@ jll = JLLInfo(;
                     :libssp_dll_a,
                     "lib\\libssp.dll.a",
                 ),
-            ]
+            ],
+            licenses = [csl_license],
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/stdlib_jllinfos/GMP_jll.jl
+++ b/JLLGenerator.jl/contrib/stdlib_jllinfos/GMP_jll.jl
@@ -1,3 +1,10 @@
+# GMP is multi-licensed:
+licenses = [
+    JLLBuildLicense("COPYINGv3", JLLGenerator.get_license_text("GPL-3.0")),
+    JLLBuildLicense("COPYINGv2", JLLGenerator.get_license_text("GPL-2.0")),
+    JLLBuildLicense("COPYING.LESSERv3", JLLGenerator.get_license_text("LGPL-3.0")),
+]
+
 jll = JLLInfo(;
     name = "GMP",
     version = v"6.2.1+5",
@@ -32,7 +39,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -65,7 +73,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -98,7 +107,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -131,7 +141,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -164,7 +175,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -197,7 +209,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -230,7 +243,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -263,7 +277,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -296,7 +311,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -329,7 +345,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -362,7 +379,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -395,7 +413,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -428,7 +447,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -461,7 +481,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -494,7 +515,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -527,7 +549,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -560,7 +583,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -593,7 +617,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -626,7 +651,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -659,7 +685,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -692,7 +719,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -725,7 +753,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -758,7 +787,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -791,7 +821,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -824,7 +855,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -857,7 +889,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -890,7 +923,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -923,7 +957,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -956,7 +991,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
         JLLBuildInfo(;
@@ -989,7 +1025,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses,
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/stdlib_jllinfos/LLD_jll.jl
+++ b/JLLGenerator.jl/contrib/stdlib_jllinfos/LLD_jll.jl
@@ -1,3 +1,5 @@
+Base.include(@__MODULE__, joinpath(@__DIR__, "llvm_license.jl"))
+
 jll = JLLInfo(;
     name = "LLD",
     version = v"15.0.7+8",
@@ -42,7 +44,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -85,7 +88,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -128,7 +132,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -171,7 +176,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -214,7 +220,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -257,7 +264,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -300,7 +308,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -343,7 +352,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -386,7 +396,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -429,7 +440,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -472,7 +484,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -515,7 +528,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -558,7 +572,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -601,7 +616,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -644,7 +660,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -687,7 +704,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -730,7 +748,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -773,7 +792,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -816,7 +836,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -859,7 +880,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -902,7 +924,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -945,7 +968,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -988,7 +1012,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1031,7 +1056,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1074,7 +1100,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1117,7 +1144,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1160,7 +1188,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1203,7 +1232,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1246,7 +1276,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1289,7 +1320,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1332,7 +1364,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools\\lld.exe",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1375,7 +1408,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools\\lld.exe",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1418,7 +1452,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools\\lld.exe",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1461,7 +1496,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools\\lld.exe",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1504,7 +1540,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1547,7 +1584,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1590,7 +1628,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1633,7 +1672,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1676,7 +1716,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1719,7 +1760,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1762,7 +1804,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1805,7 +1848,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1848,7 +1892,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1891,7 +1936,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1934,7 +1980,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1977,7 +2024,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -2020,7 +2068,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -2063,7 +2112,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -2106,7 +2156,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -2149,7 +2200,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -2192,7 +2244,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -2235,7 +2288,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools/lld",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -2278,7 +2332,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools\\lld.exe",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -2321,7 +2376,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools\\lld.exe",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -2364,7 +2420,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools\\lld.exe",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -2407,7 +2464,8 @@ jll = JLLInfo(;
                     :lld,
                     "tools\\lld.exe",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/stdlib_jllinfos/LLVMLibUnwind_jll.jl
+++ b/JLLGenerator.jl/contrib/stdlib_jllinfos/LLVMLibUnwind_jll.jl
@@ -1,3 +1,5 @@
+Base.include(@__MODULE__, joinpath(@__DIR__, "llvm_license.jl"))
+
 jll = JLLInfo(;
     name = "LLVMLibUnwind",
     version = v"14.0.6+0",
@@ -30,7 +32,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -61,7 +64,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -92,7 +96,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -123,7 +128,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -154,7 +160,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -185,7 +192,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -216,7 +224,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -247,7 +256,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -278,7 +288,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -309,7 +320,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -340,7 +352,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -371,7 +384,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -402,7 +416,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -433,7 +448,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -464,7 +480,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -495,7 +512,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/stdlib_jllinfos/LibCURL_jll.jl
+++ b/JLLGenerator.jl/contrib/stdlib_jllinfos/LibCURL_jll.jl
@@ -4,6 +4,31 @@ function libcurl_on_load_callback()
 end
 """
 
+libcurl_license = JLLBuildLicense("LICENSE.md", """
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright (c) 1996 - 2023, Daniel Stenberg, <daniel@haxx.se>, and many
+contributors, see the THANKS file.
+
+All rights reserved.
+
+Permission to use, copy, modify, and distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright
+notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS. IN
+NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall not
+be used in advertising or otherwise to promote the sale, use or other dealings
+in this Software without prior written authorization of the copyright holder.
+""")
+
 jll = JLLInfo(;
     name = "LibCURL",
     version = v"8.0.1+1",
@@ -61,7 +86,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libcurl_on_load_callback_def => libcurl_on_load_callback_def,
-            )
+            ),
+            licenses = [libcurl_license],
         ),
 
         JLLBuildInfo(;
@@ -117,7 +143,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libcurl_on_load_callback_def => libcurl_on_load_callback_def,
-            )
+            ),
+            licenses = [libcurl_license],
         ),
 
         JLLBuildInfo(;
@@ -173,7 +200,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libcurl_on_load_callback_def => libcurl_on_load_callback_def,
-            )
+            ),
+            licenses = [libcurl_license],
         ),
 
         JLLBuildInfo(;
@@ -229,7 +257,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libcurl_on_load_callback_def => libcurl_on_load_callback_def,
-            )
+            ),
+            licenses = [libcurl_license],
         ),
 
         JLLBuildInfo(;
@@ -285,7 +314,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libcurl_on_load_callback_def => libcurl_on_load_callback_def,
-            )
+            ),
+            licenses = [libcurl_license],
         ),
 
         JLLBuildInfo(;
@@ -341,7 +371,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libcurl_on_load_callback_def => libcurl_on_load_callback_def,
-            )
+            ),
+            licenses = [libcurl_license],
         ),
 
         JLLBuildInfo(;
@@ -397,7 +428,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libcurl_on_load_callback_def => libcurl_on_load_callback_def,
-            )
+            ),
+            licenses = [libcurl_license],
         ),
 
         JLLBuildInfo(;
@@ -453,7 +485,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libcurl_on_load_callback_def => libcurl_on_load_callback_def,
-            )
+            ),
+            licenses = [libcurl_license],
         ),
 
         JLLBuildInfo(;
@@ -509,7 +542,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libcurl_on_load_callback_def => libcurl_on_load_callback_def,
-            )
+            ),
+            licenses = [libcurl_license],
         ),
 
         JLLBuildInfo(;
@@ -565,7 +599,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libcurl_on_load_callback_def => libcurl_on_load_callback_def,
-            )
+            ),
+            licenses = [libcurl_license],
         ),
 
         JLLBuildInfo(;
@@ -621,7 +656,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libcurl_on_load_callback_def => libcurl_on_load_callback_def,
-            )
+            ),
+            licenses = [libcurl_license],
         ),
 
         JLLBuildInfo(;
@@ -677,7 +713,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libcurl_on_load_callback_def => libcurl_on_load_callback_def,
-            )
+            ),
+            licenses = [libcurl_license],
         ),
 
         JLLBuildInfo(;
@@ -733,7 +770,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libcurl_on_load_callback_def => libcurl_on_load_callback_def,
-            )
+            ),
+            licenses = [libcurl_license],
         ),
 
         JLLBuildInfo(;
@@ -789,7 +827,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libcurl_on_load_callback_def => libcurl_on_load_callback_def,
-            )
+            ),
+            licenses = [libcurl_license],
         ),
 
         JLLBuildInfo(;
@@ -845,7 +884,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libcurl_on_load_callback_def => libcurl_on_load_callback_def,
-            )
+            ),
+            licenses = [libcurl_license],
         ),
 
         JLLBuildInfo(;
@@ -901,7 +941,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libcurl_on_load_callback_def => libcurl_on_load_callback_def,
-            )
+            ),
+            licenses = [libcurl_license],
         ),
 
         JLLBuildInfo(;
@@ -957,7 +998,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libcurl_on_load_callback_def => libcurl_on_load_callback_def,
-            )
+            ),
+            licenses = [libcurl_license],
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/stdlib_jllinfos/LibGit2_jll.jl
+++ b/JLLGenerator.jl/contrib/stdlib_jllinfos/LibGit2_jll.jl
@@ -1,3 +1,1222 @@
+libgit2_license = JLLBuildLicense("LICENSE.md", """
+ libgit2 is Copyright (C) the libgit2 contributors,
+ unless otherwise stated. See the AUTHORS file for details.
+
+ Note that the only valid version of the GPL as far as this project
+ is concerned is _this_ particular version of the license (ie v2, not
+ v2.2 or v3.x or whatever), unless explicitly otherwise stated.
+
+----------------------------------------------------------------------
+
+			LINKING EXCEPTION
+
+ In addition to the permissions in the GNU General Public License,
+ the authors give you unlimited permission to link the compiled
+ version of this library into combinations with other programs,
+ and to distribute those combinations without any restriction
+ coming from the use of this file.  (The General Public License
+ restrictions do apply in other respects; for example, they cover
+ modification of the file, and distribution when not linked into
+ a combined executable.)
+
+----------------------------------------------------------------------
+
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+                       59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Library General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+	    How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Library General
+Public License instead of this License.
+
+----------------------------------------------------------------------
+
+The bundled ZLib code is licensed under the ZLib license:
+
+Copyright (C) 1995-2010 Jean-loup Gailly and Mark Adler
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Jean-loup Gailly        Mark Adler
+  jloup@gzip.org          madler@alumni.caltech.edu
+
+----------------------------------------------------------------------
+
+The Clar framework is licensed under the ISC license:
+
+Copyright (c) 2011-2015 Vicent Marti
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+----------------------------------------------------------------------
+
+The bundled PCRE implementation (deps/pcre/) is licensed under the BSD
+license.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the name of the University of Cambridge nor the name of Google
+      Inc. nor the names of their contributors may be used to endorse or
+      promote products derived from this software without specific prior
+      written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+----------------------------------------------------------------------
+
+The bundled winhttp definition files (deps/winhttp/) are licensed under
+the GNU LGPL (available at the end of this file).
+
+Copyright (C) 2007 Francois Gouget
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+
+----------------------------------------------------------------------
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!
+
+----------------------------------------------------------------------
+
+The bundled SHA1 collision detection code is licensed under the MIT license:
+
+MIT License
+
+Copyright (c) 2017:
+    Marc Stevens
+    Cryptology Group
+    Centrum Wiskunde & Informatica
+    P.O. Box 94079, 1090 GB Amsterdam, Netherlands
+    marc@marc-stevens.nl
+
+    Dan Shumow
+    Microsoft Research
+    danshu@microsoft.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+----------------------------------------------------------------------
+
+The bundled wildmatch code is licensed under the BSD license:
+
+Copyright Rich Salz.
+All rights reserved.
+
+Redistribution and use in any form are permitted provided that the
+following restrictions are are met:
+
+1.  Source distributions must retain this entire copyright notice
+    and comment.
+2.  Binary distributions must include the acknowledgement ``This
+    product includes software developed by Rich Salz'' in the
+    documentation or other materials provided with the
+    distribution.  This must not be represented as an endorsement
+   or promotion without specific prior written permission.
+3.  The origin of this software must not be misrepresented, either
+    by explicit claim or by omission.  Credits must appear in the
+    source and documentation.
+4.  Altered versions must be plainly marked as such in the source
+    and documentation and must not be misrepresented as being the
+    original software.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+
+----------------------------------------------------------------------
+
+Portions of the OpenSSL headers are included under the OpenSSL license:
+
+Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
+All rights reserved.
+
+This package is an SSL implementation written
+by Eric Young (eay@cryptsoft.com).
+The implementation was written so as to conform with Netscapes SSL.
+
+This library is free for commercial and non-commercial use as long as
+the following conditions are aheared to.  The following conditions
+apply to all code found in this distribution, be it the RC4, RSA,
+lhash, DES, etc., code; not just the SSL code.  The SSL documentation
+included with this distribution is covered by the same copyright terms
+except that the holder is Tim Hudson (tjh@cryptsoft.com).
+
+Copyright remains Eric Young's, and as such any Copyright notices in
+the code are not to be removed.
+If this package is used in a product, Eric Young should be given attribution
+as the author of the parts of the library used.
+This can be in the form of a textual message at program startup or
+in documentation (online or textual) provided with the package.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. All advertising materials mentioning features or use of this software
+   must display the following acknowledgement:
+   "This product includes cryptographic software written by
+    Eric Young (eay@cryptsoft.com)"
+   The word 'cryptographic' can be left out if the rouines from the library
+   being used are not cryptographic related :-).
+4. If you include any Windows specific code (or a derivative thereof) from
+   the apps directory (application code) you must include an acknowledgement:
+   "This product includes software written by Tim Hudson (tjh@cryptsoft.com)"
+
+THIS SOFTWARE IS PROVIDED BY ERIC YOUNG ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+The licence and distribution terms for any publically available version or
+derivative of this code cannot be changed.  i.e. this code cannot simply be
+copied and put under another distribution licence
+[including the GNU Public Licence.]
+
+====================================================================
+Copyright (c) 1998-2007 The OpenSSL Project.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. All advertising materials mentioning features or use of this
+   software must display the following acknowledgment:
+   "This product includes software developed by the OpenSSL Project
+   for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
+
+4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
+   endorse or promote products derived from this software without
+   prior written permission. For written permission, please contact
+   openssl-core@openssl.org.
+
+5. Products derived from this software may not be called "OpenSSL"
+   nor may "OpenSSL" appear in their names without prior written
+   permission of the OpenSSL Project.
+
+6. Redistributions of any form whatsoever must retain the following
+   acknowledgment:
+   "This product includes software developed by the OpenSSL Project
+   for use in the OpenSSL Toolkit (http://www.openssl.org/)"
+
+THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
+EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
+ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+----------------------------------------------------------------------
+
+The xoroshiro256** implementation is licensed in the public domain:
+
+Written in 2018 by David Blackman and Sebastiano Vigna (vigna@acm.org)
+
+To the extent possible under law, the author has dedicated all copyright
+and related and neighboring rights to this software to the public domain
+worldwide. This software is distributed without any warranty.
+
+See <http://creativecommons.org/publicdomain/zero/1.0/>.
+
+----------------------------------------------------------------------
+
+The built-in SHA256 support (src/hash/rfc6234) is taken from RFC 6234
+under the following license:
+
+Copyright (c) 2011 IETF Trust and the persons identified as
+authors of the code.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or
+without modification, are permitted provided that the following
+conditions are met:
+
+- Redistributions of source code must retain the above
+  copyright notice, this list of conditions and
+  the following disclaimer.
+
+- Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the following
+  disclaimer in the documentation and/or other materials provided
+  with the distribution.
+
+- Neither the name of Internet Society, IETF or IETF Trust, nor
+  the names of specific contributors, may be used to endorse or
+  promote products derived from this software without specific
+  prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+----------------------------------------------------------------------
+
+The built-in git_fs_path_basename_r() function is based on the
+Android implementation, BSD licensed:
+
+Copyright (C) 2008 The Android Open Source Project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in
+  the documentation and/or other materials provided with the
+  distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+AS IS AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+""")
+
 jll = JLLInfo(;
     name = "LibGit2",
     version = v"1.6.4+0",
@@ -40,7 +1259,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libgit2_license],
         ),
 
         JLLBuildInfo(;
@@ -81,7 +1301,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libgit2_license],
         ),
 
         JLLBuildInfo(;
@@ -122,7 +1343,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libgit2_license],
         ),
 
         JLLBuildInfo(;
@@ -163,7 +1385,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libgit2_license],
         ),
 
         JLLBuildInfo(;
@@ -204,7 +1427,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libgit2_license],
         ),
 
         JLLBuildInfo(;
@@ -245,7 +1469,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libgit2_license],
         ),
 
         JLLBuildInfo(;
@@ -286,7 +1511,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libgit2_license],
         ),
 
         JLLBuildInfo(;
@@ -327,7 +1553,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libgit2_license],
         ),
 
         JLLBuildInfo(;
@@ -368,7 +1595,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libgit2_license],
         ),
 
         JLLBuildInfo(;
@@ -409,7 +1637,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libgit2_license],
         ),
 
         JLLBuildInfo(;
@@ -450,7 +1679,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libgit2_license],
         ),
 
         JLLBuildInfo(;
@@ -491,7 +1721,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libgit2_license],
         ),
 
         JLLBuildInfo(;
@@ -532,7 +1763,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libgit2_license],
         ),
 
         JLLBuildInfo(;
@@ -573,7 +1805,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libgit2_license],
         ),
 
         JLLBuildInfo(;
@@ -614,7 +1847,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libgit2_license],
         ),
 
         JLLBuildInfo(;
@@ -655,7 +1889,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libgit2_license],
         ),
 
         JLLBuildInfo(;
@@ -696,7 +1931,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libgit2_license],
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/stdlib_jllinfos/LibSSH2_jll.jl
+++ b/JLLGenerator.jl/contrib/stdlib_jllinfos/LibSSH2_jll.jl
@@ -1,3 +1,49 @@
+libssh2_license = JLLBuildLicense("LICENSE.md", """
+/* Copyright (c) 2004-2007 Sara Golemon <sarag@libssh2.org>
+ * Copyright (c) 2005,2006 Mikhail Gusarov <dottedmag@dottedmag.net>
+ * Copyright (c) 2006-2007 The Written Word, Inc.
+ * Copyright (c) 2007 Eli Fant <elifantu@mail.ru>
+ * Copyright (c) 2009-2023 Daniel Stenberg
+ * Copyright (C) 2008, 2009 Simon Josefsson
+ * Copyright (c) 2000 Markus Friedl
+ * Copyright (c) 2015 Microsoft Corp.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms,
+ * with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *   Redistributions of source code must retain the above
+ *   copyright notice, this list of conditions and the
+ *   following disclaimer.
+ *
+ *   Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials
+ *   provided with the distribution.
+ *
+ *   Neither the name of the copyright holder nor the names
+ *   of any other contributors may be used to endorse or
+ *   promote products derived from this software without
+ *   specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ */
+""")
+
 jll = JLLInfo(;
     name = "LibSSH2",
     version = v"1.11.0+1",
@@ -34,7 +80,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libssh2_license],
         ),
 
         JLLBuildInfo(;
@@ -69,7 +116,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libssh2_license],
         ),
 
         JLLBuildInfo(;
@@ -104,7 +152,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libssh2_license],
         ),
 
         JLLBuildInfo(;
@@ -139,7 +188,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libssh2_license],
         ),
 
         JLLBuildInfo(;
@@ -174,7 +224,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libssh2_license],
         ),
 
         JLLBuildInfo(;
@@ -209,7 +260,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libssh2_license],
         ),
 
         JLLBuildInfo(;
@@ -244,7 +296,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libssh2_license],
         ),
 
         JLLBuildInfo(;
@@ -279,7 +332,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libssh2_license],
         ),
 
         JLLBuildInfo(;
@@ -314,7 +368,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libssh2_license],
         ),
 
         JLLBuildInfo(;
@@ -349,7 +404,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libssh2_license],
         ),
 
         JLLBuildInfo(;
@@ -384,7 +440,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libssh2_license],
         ),
 
         JLLBuildInfo(;
@@ -419,7 +476,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libssh2_license],
         ),
 
         JLLBuildInfo(;
@@ -454,7 +512,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libssh2_license],
         ),
 
         JLLBuildInfo(;
@@ -489,7 +548,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libssh2_license],
         ),
 
         JLLBuildInfo(;
@@ -524,7 +584,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libssh2_license],
         ),
 
         JLLBuildInfo(;
@@ -559,7 +620,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libssh2_license],
         ),
 
         JLLBuildInfo(;
@@ -594,7 +656,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libssh2_license],
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/stdlib_jllinfos/LibUnwind_jll.jl
+++ b/JLLGenerator.jl/contrib/stdlib_jllinfos/LibUnwind_jll.jl
@@ -1,3 +1,26 @@
+libunwind_license = JLLBuildLicense("LICENSE.md", """
+Copyright (c) 2002 Hewlett-Packard Co.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+""")
+
 jll = JLLInfo(;
     name = "LibUnwind",
     version = v"1.5.0+5",
@@ -32,7 +55,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libunwind_license],
         ),
 
         JLLBuildInfo(;
@@ -65,7 +89,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libunwind_license],
         ),
 
         JLLBuildInfo(;
@@ -98,7 +123,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libunwind_license],
         ),
 
         JLLBuildInfo(;
@@ -131,7 +157,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libunwind_license],
         ),
 
         JLLBuildInfo(;
@@ -164,7 +191,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libunwind_license],
         ),
 
         JLLBuildInfo(;
@@ -197,7 +225,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libunwind_license],
         ),
 
         JLLBuildInfo(;
@@ -230,7 +259,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libunwind_license],
         ),
 
         JLLBuildInfo(;
@@ -263,7 +293,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libunwind_license],
         ),
 
         JLLBuildInfo(;
@@ -296,7 +327,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libunwind_license],
         ),
 
         JLLBuildInfo(;
@@ -329,7 +361,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libunwind_license],
         ),
 
         JLLBuildInfo(;
@@ -362,7 +395,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libunwind_license],
         ),
 
         JLLBuildInfo(;
@@ -395,7 +429,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libunwind_license],
         ),
 
         JLLBuildInfo(;
@@ -428,7 +463,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [libunwind_license],
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/stdlib_jllinfos/MPFR_jll.jl
+++ b/JLLGenerator.jl/contrib/stdlib_jllinfos/MPFR_jll.jl
@@ -1,3 +1,5 @@
+mpfr_license = JLLBuildLicense("LICENSE.md", JLLGenerator.get_license_text("GPL-3.0"))
+
 jll = JLLInfo(;
     name = "MPFR",
     version = v"4.2.0+1",
@@ -30,7 +32,8 @@ jll = JLLInfo(;
                     [JLLLibraryDep(:GMP_jll, :libgmp)],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mpfr_license],
         ),
 
         JLLBuildInfo(;
@@ -61,7 +64,8 @@ jll = JLLInfo(;
                     [JLLLibraryDep(:GMP_jll, :libgmp)],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mpfr_license],
         ),
 
         JLLBuildInfo(;
@@ -92,7 +96,8 @@ jll = JLLInfo(;
                     [JLLLibraryDep(:GMP_jll, :libgmp)],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mpfr_license],
         ),
 
         JLLBuildInfo(;
@@ -123,7 +128,8 @@ jll = JLLInfo(;
                     [JLLLibraryDep(:GMP_jll, :libgmp)],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mpfr_license],
         ),
 
         JLLBuildInfo(;
@@ -154,7 +160,8 @@ jll = JLLInfo(;
                     [JLLLibraryDep(:GMP_jll, :libgmp)],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mpfr_license],
         ),
 
         JLLBuildInfo(;
@@ -185,7 +192,8 @@ jll = JLLInfo(;
                     [JLLLibraryDep(:GMP_jll, :libgmp)],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mpfr_license],
         ),
 
         JLLBuildInfo(;
@@ -216,7 +224,8 @@ jll = JLLInfo(;
                     [JLLLibraryDep(:GMP_jll, :libgmp)],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mpfr_license],
         ),
 
         JLLBuildInfo(;
@@ -247,7 +256,8 @@ jll = JLLInfo(;
                     [JLLLibraryDep(:GMP_jll, :libgmp)],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mpfr_license],
         ),
 
         JLLBuildInfo(;
@@ -278,7 +288,8 @@ jll = JLLInfo(;
                     [JLLLibraryDep(:GMP_jll, :libgmp)],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mpfr_license],
         ),
 
         JLLBuildInfo(;
@@ -309,7 +320,8 @@ jll = JLLInfo(;
                     [JLLLibraryDep(:GMP_jll, :libgmp)],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mpfr_license],
         ),
 
         JLLBuildInfo(;
@@ -340,7 +352,8 @@ jll = JLLInfo(;
                     [JLLLibraryDep(:GMP_jll, :libgmp)],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mpfr_license],
         ),
 
         JLLBuildInfo(;
@@ -371,7 +384,8 @@ jll = JLLInfo(;
                     [JLLLibraryDep(:GMP_jll, :libgmp)],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mpfr_license],
         ),
 
         JLLBuildInfo(;
@@ -402,7 +416,8 @@ jll = JLLInfo(;
                     [JLLLibraryDep(:GMP_jll, :libgmp)],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mpfr_license],
         ),
 
         JLLBuildInfo(;
@@ -433,7 +448,8 @@ jll = JLLInfo(;
                     [JLLLibraryDep(:GMP_jll, :libgmp)],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mpfr_license],
         ),
 
         JLLBuildInfo(;
@@ -464,7 +480,8 @@ jll = JLLInfo(;
                     [JLLLibraryDep(:GMP_jll, :libgmp)],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mpfr_license],
         ),
 
         JLLBuildInfo(;
@@ -495,7 +512,8 @@ jll = JLLInfo(;
                     [JLLLibraryDep(:GMP_jll, :libgmp)],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mpfr_license],
         ),
 
         JLLBuildInfo(;
@@ -526,7 +544,8 @@ jll = JLLInfo(;
                     [JLLLibraryDep(:GMP_jll, :libgmp)],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mpfr_license],
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/stdlib_jllinfos/MbedTLS_jll.jl
+++ b/JLLGenerator.jl/contrib/stdlib_jllinfos/MbedTLS_jll.jl
@@ -1,3 +1,4 @@
+mbedtls_license = JLLBuildLicense("LICENSE.md", JLLGenerator.get_license_text("Apache-2.0"))
 jll = JLLInfo(;
     name = "MbedTLS",
     version = v"2.28.2+1",
@@ -42,7 +43,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mbedtls_license],
         ),
 
         JLLBuildInfo(;
@@ -85,7 +87,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mbedtls_license],
         ),
 
         JLLBuildInfo(;
@@ -128,7 +131,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mbedtls_license],
         ),
 
         JLLBuildInfo(;
@@ -171,7 +175,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mbedtls_license],
         ),
 
         JLLBuildInfo(;
@@ -214,7 +219,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mbedtls_license],
         ),
 
         JLLBuildInfo(;
@@ -257,7 +263,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mbedtls_license],
         ),
 
         JLLBuildInfo(;
@@ -300,7 +307,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mbedtls_license],
         ),
 
         JLLBuildInfo(;
@@ -343,7 +351,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mbedtls_license],
         ),
 
         JLLBuildInfo(;
@@ -386,7 +395,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mbedtls_license],
         ),
 
         JLLBuildInfo(;
@@ -429,7 +439,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mbedtls_license],
         ),
 
         JLLBuildInfo(;
@@ -472,7 +483,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mbedtls_license],
         ),
 
         JLLBuildInfo(;
@@ -515,7 +527,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mbedtls_license],
         ),
 
         JLLBuildInfo(;
@@ -558,7 +571,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mbedtls_license],
         ),
 
         JLLBuildInfo(;
@@ -601,7 +615,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mbedtls_license],
         ),
 
         JLLBuildInfo(;
@@ -644,7 +659,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mbedtls_license],
         ),
 
         JLLBuildInfo(;
@@ -687,7 +703,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mbedtls_license],
         ),
 
         JLLBuildInfo(;
@@ -730,7 +747,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [mbedtls_license],
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/stdlib_jllinfos/MozillaCACerts_jll.jl
+++ b/JLLGenerator.jl/contrib/stdlib_jllinfos/MozillaCACerts_jll.jl
@@ -1,3 +1,4 @@
+mozilla_ca_certs_license = JLLBuildLicense("LICENSE.md", JLLGenerator.get_license_text("MPL-2.0"))
 jll = JLLInfo(;
     name = "MozillaCACerts",
     version = v"2023.1.10+0",
@@ -23,7 +24,8 @@ jll = JLLInfo(;
                     :cacert,
                     "share/cacert.pem",
                 ),
-            ]
+            ],
+            licenses = [mozilla_ca_certs_license],
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/stdlib_jllinfos/OpenBLAS_jll.jl
+++ b/JLLGenerator.jl/contrib/stdlib_jllinfos/OpenBLAS_jll.jl
@@ -18,6 +18,38 @@ if !haskey(ENV, "OPENBLAS_NUM_THREADS") &&
 end
 """
 
+openblas_license = JLLBuildLicense("LICENSE.md", """
+Copyright (c) 2011-2014, The OpenBLAS Project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+   3. Neither the name of the OpenBLAS project nor the names of 
+      its contributors may be used to endorse or promote products 
+      derived from this software without specific prior written 
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+""")
+
 jll = JLLInfo(;
     name = "OpenBLAS",
     version = v"0.3.23+2",
@@ -52,6 +84,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -84,6 +117,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -116,6 +150,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -148,6 +183,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -180,6 +216,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -212,6 +249,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -244,6 +282,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -276,6 +315,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -308,6 +348,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -340,6 +381,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -372,6 +414,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -404,6 +447,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -436,6 +480,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -468,6 +513,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -500,6 +546,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -532,6 +579,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -564,6 +612,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -596,6 +645,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -628,6 +678,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -660,6 +711,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -692,6 +744,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -724,6 +777,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -756,6 +810,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -788,6 +843,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -820,6 +876,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -852,6 +909,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -884,6 +942,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -916,6 +975,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -948,6 +1008,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -980,6 +1041,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -1012,6 +1074,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -1044,6 +1107,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -1076,6 +1140,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -1108,6 +1173,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -1140,6 +1206,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -1172,6 +1239,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -1204,6 +1272,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -1236,6 +1305,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -1268,6 +1338,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -1300,6 +1371,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -1332,6 +1404,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -1364,6 +1437,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -1396,6 +1470,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -1428,6 +1503,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -1460,6 +1536,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -1492,6 +1569,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
         JLLBuildInfo(;
@@ -1524,6 +1602,7 @@ jll = JLLInfo(;
                 ),
             ],
             init_def = openblas_init_block,
+            licenses = [openblas_license],
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/stdlib_jllinfos/OpenLibm_jll.jl
+++ b/JLLGenerator.jl/contrib/stdlib_jllinfos/OpenLibm_jll.jl
@@ -1,3 +1,121 @@
+openlibm_license = JLLBuildLicense("LICENSE.md", """
+## OpenLibm
+
+OpenLibm contains code that is covered by various licenses.
+
+The OpenLibm code derives from the FreeBSD msun and OpenBSD libm
+implementations, which in turn derives from FDLIBM 5.3. As a result, it
+has a number of fixes and updates that have accumulated over the years
+in msun, and also optimized assembly versions of many functions. These
+improvements are provided under the BSD and ISC licenses. The msun
+library also includes work placed under the public domain, which is
+noted in the individual files. Further work on making a standalone
+OpenLibm library from msun, as part of the Julia project is covered
+under the MIT license. The test files, test-double.c and test-float.c
+are under the LGPL.
+
+## Parts copyrighted by the Julia project (MIT License)
+
+>       Copyright (c) 2011-14 The Julia Project.
+>       https://github.com/JuliaMath/openlibm/graphs/contributors
+>
+>       Permission is hereby granted, free of charge, to any person obtaining
+>       a copy of this software and associated documentation files (the
+>       "Software"), to deal in the Software without restriction, including
+>       without limitation the rights to use, copy, modify, merge, publish,
+>       distribute, sublicense, and/or sell copies of the Software, and to
+>       permit persons to whom the Software is furnished to do so, subject to
+>       the following conditions:
+>
+>       The above copyright notice and this permission notice shall be
+>       included in all copies or substantial portions of the Software.
+>
+>       THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+>       EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+>       MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+>       NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+>       LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+>       OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+>       WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## Parts copyrighted by Stephen L. Moshier (ISC License)
+
+> Copyright (c) 2008 Stephen L. Moshier <steve@moshier.net>
+>
+> Permission to use, copy, modify, and distribute this software for any
+> purpose with or without fee is hereby granted, provided that the above
+> copyright notice and this permission notice appear in all copies.
+>
+> THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+> WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+> MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+> ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+> WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+> ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+> OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+## FREEBSD MSUN (FreeBSD/2-clause BSD/Simplified BSD License)
+
+>       Copyright 1992-2011 The FreeBSD Project. All rights reserved.
+>
+>       Redistribution and use in source and binary forms, with or without
+>       modification, are permitted provided that the following conditions are
+>       met:
+>
+>       1. Redistributions of source code must retain the above copyright
+>       notice, this list of conditions and the following disclaimer.
+>
+>       2. Redistributions in binary form must reproduce the above copyright
+>       notice, this list of conditions and the following disclaimer in the
+>       documentation and/or other materials provided with the distribution.
+>       THIS SOFTWARE IS PROVIDED BY THE FREEBSD PROJECT ``AS IS'' AND ANY
+>       EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+>       IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+>       PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE FREEBSD PROJECT OR
+>       CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+>       EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+>       PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+>       PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+>       LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+>       NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+>       SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+>
+>       The views and conclusions contained in the software and documentation
+>       are those of the authors and should not be interpreted as representing
+>       official policies, either expressed or implied, of the FreeBSD
+>       Project.
+
+## FDLIBM
+
+>      Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+>
+>      Developed at SunPro, a Sun Microsystems, Inc. business.
+>      Permission to use, copy, modify, and distribute this
+>      software is freely granted, provided that this notice
+>      is preserved.
+
+## Tests
+
+>   Copyright (C) 1997, 1999 Free Software Foundation, Inc.
+>   This file is part of the GNU C Library.
+>   Contributed by Andreas Jaeger <aj@suse.de>, 1997.
+>
+>   The GNU C Library is free software; you can redistribute it and/or
+>   modify it under the terms of the GNU Lesser General Public
+>   License as published by the Free Software Foundation; either
+>   version 2.1 of the License, or (at your option) any later version.
+>
+>   The GNU C Library is distributed in the hope that it will be useful,
+>   but WITHOUT ANY WARRANTY; without even the implied warranty of
+>   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+>   Lesser General Public License for more details.
+>
+>   You should have received a copy of the GNU Lesser General Public
+>   License along with the GNU C Library; if not, write to the Free
+>   Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+>   02111-1307 USA.
+""")
+
 jll = JLLInfo(;
     name = "OpenLibm",
     version = v"0.8.1+2",
@@ -25,7 +143,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [openlibm_license],
         ),
 
         JLLBuildInfo(;
@@ -51,7 +170,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [openlibm_license],
         ),
 
         JLLBuildInfo(;
@@ -77,7 +197,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [openlibm_license],
         ),
 
         JLLBuildInfo(;
@@ -103,7 +224,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [openlibm_license],
         ),
 
         JLLBuildInfo(;
@@ -129,7 +251,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [openlibm_license],
         ),
 
         JLLBuildInfo(;
@@ -155,7 +278,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [openlibm_license],
         ),
 
         JLLBuildInfo(;
@@ -181,7 +305,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [openlibm_license],
         ),
 
         JLLBuildInfo(;
@@ -207,7 +332,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [openlibm_license],
         ),
 
         JLLBuildInfo(;
@@ -233,7 +359,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [openlibm_license],
         ),
 
         JLLBuildInfo(;
@@ -259,7 +386,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [openlibm_license],
         ),
 
         JLLBuildInfo(;
@@ -285,7 +413,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [openlibm_license],
         ),
 
         JLLBuildInfo(;
@@ -311,7 +440,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [openlibm_license],
         ),
 
         JLLBuildInfo(;
@@ -337,7 +467,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [openlibm_license],
         ),
 
         JLLBuildInfo(;
@@ -363,7 +494,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [openlibm_license],
         ),
 
         JLLBuildInfo(;
@@ -389,7 +521,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [openlibm_license],
         ),
 
         JLLBuildInfo(;
@@ -415,7 +548,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [openlibm_license],
         ),
 
         JLLBuildInfo(;
@@ -441,7 +575,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [openlibm_license],
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/stdlib_jllinfos/PCRE2_jll.jl
+++ b/JLLGenerator.jl/contrib/stdlib_jllinfos/PCRE2_jll.jl
@@ -1,3 +1,100 @@
+pcre2_license = JLLBuildLicense("LICENSE.md", """
+PCRE2 LICENCE
+-------------
+
+PCRE2 is a library of functions to support regular expressions whose syntax
+and semantics are as close as possible to those of the Perl 5 language.
+
+Releases 10.00 and above of PCRE2 are distributed under the terms of the "BSD"
+licence, as specified below, with one exemption for certain binary
+redistributions. The documentation for PCRE2, supplied in the "doc" directory,
+is distributed under the same terms as the software itself. The data in the
+testdata directory is not copyrighted and is in the public domain.
+
+The basic library functions are written in C and are freestanding. Also
+included in the distribution is a just-in-time compiler that can be used to
+optimize pattern matching. This is an optional feature that can be omitted when
+the library is built.
+
+
+THE BASIC LIBRARY FUNCTIONS
+---------------------------
+
+Written by:       Philip Hazel
+Email local part: Philip.Hazel
+Email domain:     gmail.com
+
+Retired from University of Cambridge Computing Service,
+Cambridge, England.
+
+Copyright (c) 1997-2022 University of Cambridge
+All rights reserved.
+
+
+PCRE2 JUST-IN-TIME COMPILATION SUPPORT
+--------------------------------------
+
+Written by:       Zoltan Herczeg
+Email local part: hzmester
+Email domain:     freemail.hu
+
+Copyright(c) 2010-2022 Zoltan Herczeg
+All rights reserved.
+
+
+STACK-LESS JUST-IN-TIME COMPILER
+--------------------------------
+
+Written by:       Zoltan Herczeg
+Email local part: hzmester
+Email domain:     freemail.hu
+
+Copyright(c) 2009-2022 Zoltan Herczeg
+All rights reserved.
+
+
+THE "BSD" LICENCE
+-----------------
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notices,
+      this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright
+      notices, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the name of the University of Cambridge nor the names of any
+      contributors may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+
+EXEMPTION FOR BINARY LIBRARY-LIKE PACKAGES
+------------------------------------------
+
+The second condition in the BSD licence (covering binary redistributions) does
+not apply all the way down a chain of software. If binary package A includes
+PCRE2, it must respect the condition, but if package B is software that
+includes package A, the condition is not imposed on package B unless it uses
+PCRE2 independently.
+
+End
+""")
+
 jll = JLLInfo(;
     name = "PCRE2",
     version = v"10.42.0+1",
@@ -37,7 +134,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [pcre2_license],
         ),
 
         JLLBuildInfo(;
@@ -75,7 +173,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [pcre2_license],
         ),
 
         JLLBuildInfo(;
@@ -113,7 +212,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [pcre2_license],
         ),
 
         JLLBuildInfo(;
@@ -151,7 +251,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [pcre2_license],
         ),
 
         JLLBuildInfo(;
@@ -189,7 +290,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [pcre2_license],
         ),
 
         JLLBuildInfo(;
@@ -227,7 +329,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [pcre2_license],
         ),
 
         JLLBuildInfo(;
@@ -265,7 +368,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [pcre2_license],
         ),
 
         JLLBuildInfo(;
@@ -303,7 +407,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [pcre2_license],
         ),
 
         JLLBuildInfo(;
@@ -341,7 +446,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [pcre2_license],
         ),
 
         JLLBuildInfo(;
@@ -379,7 +485,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [pcre2_license],
         ),
 
         JLLBuildInfo(;
@@ -417,7 +524,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [pcre2_license],
         ),
 
         JLLBuildInfo(;
@@ -455,7 +563,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [pcre2_license],
         ),
 
         JLLBuildInfo(;
@@ -493,7 +602,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [pcre2_license],
         ),
 
         JLLBuildInfo(;
@@ -531,7 +641,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [pcre2_license],
         ),
 
         JLLBuildInfo(;
@@ -569,7 +680,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [pcre2_license],
         ),
 
         JLLBuildInfo(;
@@ -607,7 +719,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [pcre2_license],
         ),
 
         JLLBuildInfo(;
@@ -645,7 +758,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [pcre2_license],
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/stdlib_jllinfos/SuiteSparse_jll.jl
+++ b/JLLGenerator.jl/contrib/stdlib_jllinfos/SuiteSparse_jll.jl
@@ -1,3 +1,1043 @@
+suitesparse_license = JLLBuildLicense("LICENSE.md", """
+This file lists all licenses for all packages in SuiteSparse, for your
+convenience.  Each package has its own separate license, which can be
+found in the lists below.
+
+==> SPEX/License/license.txt <==
+
+    SPEX: a Sparse Left-looking Integer-Preserving LU Factorization
+
+    Copyright (c) 2019-2022, Christopher Lourenco, JinHao Chen, Erick Moreno-
+    Centeno, and Timothy A. Davis.
+
+    Available at:
+
+        https://github.com/clouren/SPEX
+        http://suitesparse.com
+
+    Contact Chris Lourenco, chrisjlourenco@gmail.com, or Tim Davis
+    (timdavis@aldenmath.com or DrTimothyAldenDavis@gmail.com) for a commercial
+    license.
+
+    --------------------------------------------------------------------------------
+
+    SPEX is free software; you can redistribute it and/or modify
+    it under the terms of either:
+
+      * the GNU Lesser General Public License as published by the Free
+        Software Foundation; either version 3 of the License, or (at your
+        option) any later version.
+
+    or
+
+      * the GNU General Public License as published by the Free Software
+        Foundation; either version 2 of the License, or (at your option) any
+        later version.
+
+    or both in parallel, as here.
+
+    SPEX is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+    or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received copies of the GNU General Public License and the
+    GNU Lesser General Public License along with this software.  If not,
+    see https://www.gnu.org/licenses/.
+
+==> AMD/Doc/License.txt <==
+
+    AMD, Copyright (c), 1996-2022, Timothy A. Davis,
+    Patrick R. Amestoy, and Iain S. Duff.  All Rights Reserved.
+
+    Availability:
+
+        http://suitesparse.com
+
+    -------------------------------------------------------------------------------
+    AMD License: BSD 3-clause:
+    -------------------------------------------------------------------------------
+
+        Redistribution and use in source and binary forms, with or without
+        modification, are permitted provided that the following conditions are met:
+            * Redistributions of source code must retain the above copyright
+              notice, this list of conditions and the following disclaimer.
+            * Redistributions in binary form must reproduce the above copyright
+              notice, this list of conditions and the following disclaimer in the
+              documentation and/or other materials provided with the distribution.
+            * Neither the name of the organizations to which the authors are
+              affiliated, nor the names of its contributors may be used to endorse
+              or promote products derived from this software without specific prior
+              written permission.
+
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+        AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+        IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+        ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+        DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+        (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+        SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+        CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+        LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+        OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+        DAMAGE.
+
+==> BTF/Doc/License.txt <==
+    BTF, Copyright (C) 2004-2022, University of Florida
+    by Timothy A. Davis and Ekanathan Palamadai.
+    BTF is also available under other licenses; contact authors for details.
+    http://suitesparse.com
+
+    --------------------------------------------------------------------------------
+
+    BTF is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    BTF is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this Module; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+==> CAMD/Doc/License.txt <==
+
+    CAMD, Copyright (c) by Timothy A. Davis,
+    Yanqing Chen,
+    Patrick R. Amestoy, and Iain S. Duff.  All Rights Reserved.
+    CAMD is available under alternate licenses, contact T. Davis for details.
+
+    CAMD License: BSD 3-clause
+
+        Redistribution and use in source and binary forms, with or without
+        modification, are permitted provided that the following conditions are met:
+            * Redistributions of source code must retain the above copyright
+              notice, this list of conditions and the following disclaimer.
+            * Redistributions in binary form must reproduce the above copyright
+              notice, this list of conditions and the following disclaimer in the
+              documentation and/or other materials provided with the distribution.
+            * Neither the name of the organizations to which the authors are
+              affiliated, nor the names of its contributors may be used to endorse
+              or promote products derived from this software without specific prior
+              written permission.
+
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+        AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+        IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+        ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+        DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+        (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+        SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+        CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+        LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+        OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+        DAMAGE.
+
+    Availability:
+
+        http://suitesparse.com
+
+==> CCOLAMD/Doc/License.txt <==
+
+    CCOLAMD: constrained column approximate minimum degree ordering
+    Copyright (C) 2005-2022, Univ. of Florida.  Authors: Timothy A. Davis,
+    Sivasankaran Rajamanickam, and Stefan Larimore.  Closely based on COLAMD by
+    Davis, Stefan Larimore, in collaboration with Esmond Ng, and John Gilbert.
+    http://suitesparse.com
+
+    --------------------------------------------------------------------------------
+
+    CCOLAMD license: BSD 3-clause:
+
+        Redistribution and use in source and binary forms, with or without
+        modification, are permitted provided that the following conditions are met:
+            * Redistributions of source code must retain the above copyright
+              notice, this list of conditions and the following disclaimer.
+            * Redistributions in binary form must reproduce the above copyright
+              notice, this list of conditions and the following disclaimer in the
+              documentation and/or other materials provided with the distribution.
+            * Neither the name of the organizations to which the authors are
+              affiliated, nor the names of its contributors may be used to endorse
+              or promote products derived from this software without specific prior
+              written permission.
+
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+        AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+        IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+        ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+        DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+        (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+        SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+        CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+        LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+        OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+        DAMAGE.
+
+    --------------------------------------------------------------------------------
+
+==> CHOLMOD/Doc/License.txt <==
+        --------------------------------------------------------------------------------
+        ==> Check/License.txt <==
+        --------------------------------------------------------------------------------
+
+            CHOLMOD/Check Module.  Copyright (C) 2005-2022, Timothy A. Davis CHOLMOD is
+            also available under other licenses; contact authors for details.
+            http://suitesparse.com
+
+            Note that this license is for the CHOLMOD/Check module only.
+            All CHOLMOD modules are licensed separately.
+
+            ----------------------------------------------------------------------------
+
+            This Module is free software; you can redistribute it and/or
+            modify it under the terms of the GNU Lesser General Public
+            License as published by the Free Software Foundation; either
+            version 2.1 of the License, or (at your option) any later version.
+
+            This Module is distributed in the hope that it will be useful,
+            but WITHOUT ANY WARRANTY; without even the implied warranty of
+            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+            Lesser General Public License for more details.
+
+            You should have received a copy of the GNU Lesser General Public
+            License along with this Module; if not, write to the Free Software
+            Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+        --------------------------------------------------------------------------------
+        ==> Cholesky/License.txt <==
+        --------------------------------------------------------------------------------
+
+            CHOLMOD/Cholesky module, Copyright (C) 2005-2022, Timothy A. Davis.
+            CHOLMOD is also available under other licenses; contact authors for
+            details.  http://suitesparse.com
+
+            Note that this license is for the CHOLMOD/Cholesky module only.
+            All CHOLMOD modules are licensed separately.
+
+            ----------------------------------------------------------------------------
+
+
+            This Module is free software; you can redistribute it and/or
+            modify it under the terms of the GNU Lesser General Public
+            License as published by the Free Software Foundation; either
+            version 2.1 of the License, or (at your option) any later version.
+
+            This Module is distributed in the hope that it will be useful,
+            but WITHOUT ANY WARRANTY; without even the implied warranty of
+            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+            Lesser General Public License for more details.
+
+            You should have received a copy of the GNU Lesser General Public
+            License along with this Module; if not, write to the Free Software
+            Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+        --------------------------------------------------------------------------------
+        ==> Core/License.txt <==
+        --------------------------------------------------------------------------------
+
+            CHOLMOD/Core Module.  Copyright (C) 2005-2022, Univ. of Florida.  Author:
+            Timothy A. Davis.  CHOLMOD is also available under other licenses; contact
+            authors for details.  http://suitesparse.com
+
+            Note that this license is for the CHOLMOD/Core module only.
+            All CHOLMOD modules are licensed separately.
+
+
+            ----------------------------------------------------------------------------
+
+
+            This Module is free software; you can redistribute it and/or
+            modify it under the terms of the GNU Lesser General Public
+            License as published by the Free Software Foundation; either
+            version 2.1 of the License, or (at your option) any later version.
+
+            This Module is distributed in the hope that it will be useful,
+            but WITHOUT ANY WARRANTY; without even the implied warranty of
+            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+            Lesser General Public License for more details.
+
+            You should have received a copy of the GNU Lesser General Public
+            License along with this Module; if not, write to the Free Software
+            Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+        --------------------------------------------------------------------------------
+        ==> Demo/License.txt <==
+        --------------------------------------------------------------------------------
+
+            CHOLMOD/Demo Module.  Copyright (C) 2005-2022, Timothy A. Davis.  CHOLMOD
+            is also available under other licenses; contact authors for details.
+            http://suitesparse.com
+
+            Note that this license is for the CHOLMOD/Demo module only.
+            All CHOLMOD modules are licensed separately.
+
+
+            ----------------------------------------------------------------------------
+
+
+            This Module is free software; you can redistribute it and/or
+            modify it under the terms of the GNU General Public License
+            as published by the Free Software Foundation; either version 2
+            of the License, or (at your option) any later version.
+
+            This Module is distributed in the hope that it will be useful,
+            but WITHOUT ANY WARRANTY; without even the implied warranty of
+            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+            GNU General Public License for more details.
+
+            You should have received a copy of the GNU General Public License
+            along with this Module; if not, write to the Free Software
+            Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA.
+
+        --------------------------------------------------------------------------------
+        ==> Include/License.txt <==
+        --------------------------------------------------------------------------------
+
+            CHOLMOD/Include/* files.  Copyright (C) 2005-2022, either Univ. of Florida
+            or T. Davis, depending on the file.
+
+            Each file is licensed separately, according to the Module for which it
+            contains definitions and prototypes:
+
+            Include/cholmod.h               LGPL
+            Include/cholmod_camd.h          part of Partition module
+            Include/cholmod_check.h         part of Check module
+            Include/cholmod_cholesky.h      part of Cholesky module
+            Include/cholmod_complexity.h    LGPL
+            Include/cholmod_config.h        LGPL
+            Include/cholmod_core.h          part of Core module
+            Include/cholmod_function.h      no license; freely usable, no restrictions
+            Include/cholmod_gpu.h           part of GPU module
+            Include/cholmod_gpu_kernels.h   part of GPU module
+            Include/cholmod_internal.h      LGPL
+            Include/cholmod_io64.h          LGPL
+            Include/cholmod_matrixops.h     part of MatrixOps module
+            Include/cholmod_modify.h        part of Modify module
+            Include/cholmod_partition.h     part of Partition module
+            Include/cholmod_supernodal.h    part of Supernodal module
+            Include/cholmod_template.h      LGPL
+
+        --------------------------------------------------------------------------------
+        ==> MATLAB/License.txt <==
+        --------------------------------------------------------------------------------
+
+            CHOLMOD/MATLAB Module.  Copyright (C) 2005-2022, Timothy A. Davis.  CHOLMOD
+            is also available under other licenses; contact authors for details.
+            MATLAB(tm) is a Registered Trademark of The MathWorks, Inc.
+            http://suitesparse.com
+
+            Note that this license is for the CHOLMOD/MATLAB module only.
+            All CHOLMOD modules are licensed separately.
+
+            ----------------------------------------------------------------------------
+
+
+            This Module is free software; you can redistribute it and/or
+            modify it under the terms of the GNU General Public License
+            as published by the Free Software Foundation; either version 2
+            of the License, or (at your option) any later version.
+
+            This Module is distributed in the hope that it will be useful,
+            but WITHOUT ANY WARRANTY; without even the implied warranty of
+            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+            GNU General Public License for more details.
+
+            You should have received a copy of the GNU General Public License
+            along with this Module; if not, write to the Free Software
+            Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA.
+
+        --------------------------------------------------------------------------------
+        ==> MatrixOps/License.txt <==
+        --------------------------------------------------------------------------------
+
+            CHOLMOD/MatrixOps Module.  Copyright (C) 2005-2022, Timothy A. Davis.
+            CHOLMOD is also available under other licenses; contact authors for
+            details.  http://suitesparse.com
+
+            Note that this license is for the CHOLMOD/MatrixOps module only.
+            All CHOLMOD modules are licensed separately.
+
+
+            ----------------------------------------------------------------------------
+
+
+            This Module is free software; you can redistribute it and/or
+            modify it under the terms of the GNU General Public License
+            as published by the Free Software Foundation; either version 2
+            of the License, or (at your option) any later version.
+
+            This Module is distributed in the hope that it will be useful,
+            but WITHOUT ANY WARRANTY; without even the implied warranty of
+            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+            GNU General Public License for more details.
+
+            You should have received a copy of the GNU General Public License
+            along with this Module; if not, write to the Free Software
+            Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA.
+
+        --------------------------------------------------------------------------------
+        ==> Modify/License.txt <==
+        --------------------------------------------------------------------------------
+
+            CHOLMOD/Modify Module.  Copyright (C) 2005-2022, Timothy A. Davis and
+            William W. Hager.  CHOLMOD is also available under other licenses; contact
+            authors for details.  http://suitesparse.com
+
+            Note that this license is for the CHOLMOD/Modify module only.
+            All CHOLMOD modules are licensed separately.
+
+
+            ----------------------------------------------------------------------------
+
+
+            This Module is free software; you can redistribute it and/or
+            modify it under the terms of the GNU General Public License
+            as published by the Free Software Foundation; either version 2
+            of the License, or (at your option) any later version.
+
+            This Module is distributed in the hope that it will be useful,
+            but WITHOUT ANY WARRANTY; without even the implied warranty of
+            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+            GNU General Public License for more details.
+
+            You should have received a copy of the GNU General Public License
+            along with this Module; if not, write to the Free Software
+            Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA.
+
+        --------------------------------------------------------------------------------
+        ==> Partition/License.txt <==
+        --------------------------------------------------------------------------------
+
+            CHOLMOD/Partition Module.
+            Copyright (C) 2005-2022, Univ. of Florida.  Author: Timothy A. Davis
+            CHOLMOD is also available under other licenses; contact authors for details.
+            http://suitesparse.com
+
+            Note that this license is for the CHOLMOD/Partition module only.
+            All CHOLMOD modules are licensed separately.
+
+
+            ----------------------------------------------------------------------------
+
+
+            This Module is free software; you can redistribute it and/or
+            modify it under the terms of the GNU Lesser General Public
+            License as published by the Free Software Foundation; either
+            version 2.1 of the License, or (at your option) any later version.
+
+            This Module is distributed in the hope that it will be useful,
+            but WITHOUT ANY WARRANTY; without even the implied warranty of
+            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+            Lesser General Public License for more details.
+
+            You should have received a copy of the GNU Lesser General Public
+            License along with this Module; if not, write to the Free Software
+            Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+        --------------------------------------------------------------------------------
+        ==> Supernodal/License.txt <==
+        --------------------------------------------------------------------------------
+
+            CHOLMOD/Supernodal Module.
+            Copyright (C) 2005-2022, Timothy A. Davis
+            CHOLMOD is also available under other licenses; contact authors for details.
+            http://suitesparse.com
+
+            Note that this license is for the CHOLMOD/Supernodal module only.
+            All CHOLMOD modules are licensed separately.
+
+
+            ----------------------------------------------------------------------------
+
+
+            This Module is free software; you can redistribute it and/or
+            modify it under the terms of the GNU General Public License
+            as published by the Free Software Foundation; either version 2
+            of the License, or (at your option) any later version.
+
+            This Module is distributed in the hope that it will be useful,
+            but WITHOUT ANY WARRANTY; without even the implied warranty of
+            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+            GNU General Public License for more details.
+
+            You should have received a copy of the GNU General Public License
+            along with this Module; if not, write to the Free Software
+            Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA.
+
+        --------------------------------------------------------------------------------
+        ==> Tcov/License.txt <==
+        --------------------------------------------------------------------------------
+
+            CHOLMOD/Tcov Module.  Copyright (C) 2005-2022, Timothy A. Davis
+            CHOLMOD is also available under other licenses; contact authors for details.
+            http://suitesparse.com
+
+            Note that this license is for the CHOLMOD/Tcov module only.
+            All CHOLMOD modules are licensed separately.
+
+
+            ----------------------------------------------------------------------------
+
+
+            This Module is free software; you can redistribute it and/or
+            modify it under the terms of the GNU General Public License
+            as published by the Free Software Foundation; either version 2
+            of the License, or (at your option) any later version.
+
+            This Module is distributed in the hope that it will be useful,
+            but WITHOUT ANY WARRANTY; without even the implied warranty of
+            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+            GNU General Public License for more details.
+
+            You should have received a copy of the GNU General Public License
+            along with this Module; if not, write to the Free Software
+            Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA.
+
+        --------------------------------------------------------------------------------
+        ==> Valgrind/License.txt <==
+        --------------------------------------------------------------------------------
+
+            CHOLMOD/Valgrind Module.  Copyright (C) 2005-2022, Timothy A. Davis.
+            CHOLMOD is also available under other licenses; contact authors for details.
+            http://suitesparse.com
+
+            Note that this license is for the CHOLMOD/Valgrind module only.
+            All CHOLMOD modules are licensed separately.
+
+
+            ----------------------------------------------------------------------------
+
+
+            This Module is free software; you can redistribute it and/or
+            modify it under the terms of the GNU General Public License
+            as published by the Free Software Foundation; either version 2
+            of the License, or (at your option) any later version.
+
+            This Module is distributed in the hope that it will be useful,
+            but WITHOUT ANY WARRANTY; without even the implied warranty of
+            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+            GNU General Public License for more details.
+
+            You should have received a copy of the GNU General Public License
+            along with this Module; if not, write to the Free Software
+            Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA.
+
+==> COLAMD/Doc/License.txt <==
+    COLAMD, Copyright 1998-2022, Timothy A. Davis.  http://suitesparse.com
+    http://suitesparse.com
+
+    COLAMD License: BSD 3-clause
+
+        Redistribution and use in source and binary forms, with or without
+        modification, are permitted provided that the following conditions are met:
+            * Redistributions of source code must retain the above copyright
+              notice, this list of conditions and the following disclaimer.
+            * Redistributions in binary form must reproduce the above copyright
+              notice, this list of conditions and the following disclaimer in the
+              documentation and/or other materials provided with the distribution.
+            * Neither the name of the organizations to which the authors are
+              affiliated, nor the names of its contributors may be used to endorse
+              or promote products derived from this software without specific prior
+              written permission.
+
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+        AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+        IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+        ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+        DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+        (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+        SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+        CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+        LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+        OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+        DAMAGE.
+
+==> CSparse/Doc/License.txt <==
+    CSparse: a Concise Sparse matrix package.
+    Copyright (c) 2006-2022, Timothy A. Davis.
+    http://suitesparse.com
+
+    --------------------------------------------------------------------------------
+
+    CSparse is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    CSparse is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this Module; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+==> CXSparse/Doc/License.txt <==
+    CXSparse: a Concise Sparse matrix package - Extended.
+    Copyright (c) 2006-2022, Timothy A. Davis.
+    http://suitesparse.com
+
+    --------------------------------------------------------------------------------
+
+    CXSparse is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    CXSparse is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this Module; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+==> CXSparse_newfiles/Doc/License.txt <==
+    CXSparse: a Concise Sparse matrix package - Extended.
+    Copyright (c) 2006-2022, Timothy A. Davis.
+    http://suitesparse.com
+
+    --------------------------------------------------------------------------------
+
+    CXSparse is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    CXSparse is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this Module; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+==> GPUQREngine/Doc/License.txt <==
+    GPUQREngine Copyright (c) 2013-2022, Timothy A. Davis, Sencer Nuri Yeralan,
+    and Sanjay Ranka.
+    http://suitesparse.com
+
+    GPUQREngine is free software; you can redistribute it and/or modify it under
+    the terms of the GNU General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+
+    GPUQREngine is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along with
+    this Module; if not, write to the Free Software Foundation, Inc., 51 Franklin
+    Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+==> KLU/Doc/License.txt <==
+    KLU, Copyright (C) 2004-2022, University of Florida
+    by Timothy A. Davis and Ekanathan Palamadai.
+    KLU is also available under other licenses; contact authors for details.
+    http://suitesparse.com
+
+    --------------------------------------------------------------------------------
+
+    KLU is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    KLU is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this Module; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+==> LDL/Doc/License.txt <==
+    LDL Copyright (c) 2005-2022 by Timothy A. Davis.
+    LDL is also available under other licenses; contact the author for details.
+    http://suitesparse.com
+
+    --------------------------------------------------------------------------------
+
+    LDL is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    LDL is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this Module; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+==> MATLAB_Tools/Doc/License.txt <==
+    The MATLAB_Tools collection of packages is
+    Copyright (c), Timothy A. Davis, All Rights Reserved,
+    with the exception of the spqr_rank package, which is
+    Copyright (c), Timothy A. Davis and Les Foster, All Rights Reserved,
+
+    All packages are available under alternative licenses.
+    Contact the authors for details.
+
+    --------------------------------------------------------------------------------
+    MATLAB_Tools License, with the exception of SSMULT and SuiteSparseCollection:
+    --------------------------------------------------------------------------------
+
+        Redistribution and use in source and binary forms, with or without
+        modification, are permitted provided that the following conditions are met:
+            * Redistributions of source code must retain the above copyright
+              notice, this list of conditions and the following disclaimer.
+            * Redistributions in binary form must reproduce the above copyright
+              notice, this list of conditions and the following disclaimer in the
+              documentation and/or other materials provided with the distribution.
+            * Neither the name of the organizations to which the authors are
+              affiliated, nor the names of its contributors may be used to endorse
+              or promote products derived from this software without specific prior
+              written permission.
+
+        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+        AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+        IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+        ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+        DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+        (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+        SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+        CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+        LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+        OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+        DAMAGE.
+
+    --------------------------------------------------------------------------------
+    SuiteSparseCollection License:
+    --------------------------------------------------------------------------------
+
+        SuiteSparseCollection is free software; you can redistribute it and/or
+        modify it under the terms of the GNU General Public License
+        as published by the Free Software Foundation; either version 2
+        of the License, or (at your option) any later version.
+
+        SuiteSparseCollection is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+        GNU General Public License for more details.
+
+        You should have received a copy of the GNU General Public License
+        along with this package; if not, write to the Free Software Foundation,
+        Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+    --------------------------------------------------------------------------------
+    SSMULT License:
+    --------------------------------------------------------------------------------
+
+        SSMULT, Copyright (c) 2007-2022, Timothy A. Davis,
+        http://suitesparse.com.
+
+        SSMULT is free software; you can redistribute it and/or modify it under the
+        terms of the GNU General Public License as published by the Free Software
+        Foundation; either version 2 of the License, or (at your option) any later
+        version.
+
+        SSMULT is distributed in the hope that it will be useful, but WITHOUT ANY
+        WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+        FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+        details.
+
+        You should have received a copy of the GNU General Public License along
+        with this package; if not, write to the Free Software Foundation, Inc., 51
+        Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+==> RBio/Doc/License.txt <==
+    RBio toolbox.  Copyright (C) 2006-2022, Timothy A. Davis
+    RBio is also available under other licenses; contact authors for details.
+    http://suitesparse.com
+
+    --------------------------------------------------------------------------------
+
+    RBio is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License
+    as published by the Free Software Foundation; either version 2
+    of the License, or (at your option) any later version.
+
+    RBio is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this Module; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+==> SPQR/Doc/License.txt <==
+    SPQR, Copyright 2008-2022 by Timothy A. Davis.
+    All Rights Reserved.
+    SPQR is available under alternate licenses, contact T. Davis for details.
+
+    SPQR License:
+
+        Your use or distribution of SPQR or any modified version of
+        SPQR implies that you agree to this License.
+
+        This library is free software; you can redistribute it and/or
+        modify it under the terms of the GNU General Public
+        License as published by the Free Software Foundation; either
+        version 2 of the License, or (at your option) any later version.
+
+        This library is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+        General Public License for more details.
+
+        You should have received a copy of the GNU General Public
+        License along with this library; if not, write to the Free Software
+        Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+        USA
+
+        Permission is hereby granted to use or copy this program under the
+        terms of the GNU GPL, provided that the Copyright, this License,
+        and the Availability of the original version is retained on all copies.
+        User documentation of any code that uses this code or any modified
+        version of this code must cite the Copyright, this License, the
+        Availability note, and "Used by permission." Permission to modify
+        the code and to distribute modified code is granted, provided the
+        Copyright, this License, and the Availability note are retained,
+        and a notice that the code was modified is included.
+
+    Availability:
+
+        http://suitesparse.com
+
+
+==> SuiteSparse_GPURuntime/Doc/License.txt <==
+    SuiteSparse_GPURuntime Copyright (c) 2013-2022, Timothy A. Davis,
+    Sencer Nuri Yeralan, and Sanjay Ranka.  http://suitesparse.com
+
+    --------------------------------------------------------------------------------
+
+    SuiteSparse_GPURuntime is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by the Free
+    Software Foundation; either version 2 of the License, or (at your option) any
+    later version.
+
+    SuiteSparse_GPURuntime is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along with
+    this Module; if not, write to the Free Software Foundation, Inc., 51 Franklin
+    Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+==> ssget/Doc/License.txt <==
+    Copyright (c), 2009-2022, Timothy A. Davis, All Rights Reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+        * Redistributions of source code must retain the above copyright
+          notice, this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above copyright
+          notice, this list of conditions and the following disclaimer in the
+          documentation and/or other materials provided with the distribution.
+        * Neither the name of the organizations to which the authors are
+          affiliated, nor the names of its contributors may be used to endorse
+          or promote products derived from this software without specific prior
+          written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+    OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+    DAMAGE.
+
+
+==> UMFPACK/Doc/License.txt <==
+    UMFPACK, Copyright 1995-2022 by Timothy A. Davis.
+    All Rights Reserved.
+    UMFPACK is available under alternate licenses, contact T. Davis for details.
+
+    UMFPACK License:
+
+        Your use or distribution of UMFPACK or any modified version of
+        UMFPACK implies that you agree to this License.
+
+        This library is free software; you can redistribute it and/or
+        modify it under the terms of the GNU General Public
+        License as published by the Free Software Foundation; either
+        version 2 of the License, or (at your option) any later version.
+
+        This library is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+        General Public License for more details.
+
+        You should have received a copy of the GNU General Public
+        License along with this library; if not, write to the Free Software
+        Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+        USA
+
+        Permission is hereby granted to use or copy this program under the
+        terms of the GNU GPL, provided that the Copyright, this License,
+        and the Availability of the original version is retained on all copies.
+        User documentation of any code that uses this code or any modified
+        version of this code must cite the Copyright, this License, the
+        Availability note, and "Used by permission." Permission to modify
+        the code and to distribute modified code is granted, provided the
+        Copyright, this License, and the Availability note are retained,
+        and a notice that the code was modified is included.
+
+    Availability:
+
+        http://suitesparse.com
+
+
+==> CSparse/MATLAB/ssget/Doc/License.txt <==
+    Copyright (c), 2009-2022, Timothy A. Davis, All Rights Reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+        * Redistributions of source code must retain the above copyright
+          notice, this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above copyright
+          notice, this list of conditions and the following disclaimer in the
+          documentation and/or other materials provided with the distribution.
+        * Neither the name of the organizations to which the authors are
+          affiliated, nor the names of its contributors may be used to endorse
+          or promote products derived from this software without specific prior
+          written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+    OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+    DAMAGE.
+
+
+==> CXSparse/MATLAB/ssget/Doc/License.txt <==
+    Copyright (c), 2009-2022, Timothy A. Davis, All Rights Reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+        * Redistributions of source code must retain the above copyright
+          notice, this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above copyright
+          notice, this list of conditions and the following disclaimer in the
+          documentation and/or other materials provided with the distribution.
+        * Neither the name of the organizations to which the authors are
+          affiliated, nor the names of its contributors may be used to endorse
+          or promote products derived from this software without specific prior
+          written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+    OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+    DAMAGE.
+
+==> GraphBLAS/LICENSE <==
+
+    SuiteSparse:GraphBLAS, Timothy A. Davis, (c) 2017-2021, All Rights Reserved.
+    The following Apache-2.0 applies to all of SuiteSparse:GraphBLAS except for the
+    @GrB MATLAB interface:
+
+        SPDX-License-Identifier: Apache-2.0
+
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use SuiteSparse:GraphBLAS except in compliance with the
+        License.  You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+
+    No files that are compiled and packaged as part of the libgraphblas.so or
+    libgraphblas.a libraries are licensed under the GNU GPLv3.  All of those files
+    are licensed under the Apache-2.0 license.
+
+    ================================================================================
+
+    The @GrB MATLAB interface, including its test suite and demos (all files in the
+    GraphBLAS/GraphBLAS folder) are not under the above Apache-2.0 license, but
+    under the GNU GPLv3 (or later) license instead.  Refer to the file
+    GraphBLAS/GraphBLAS/@GrB/LICENSE for details.
+
+    All files throughout this package and the @GrB MATLAB interface are tagged
+    with an SPDX license identifier, file by file.  Either:
+
+        SPDX-License-Identifier: Apache-2.0
+
+    or, for the @GrB MATLAB interface, its test suite, and demos:
+
+        SPDX-License-Identifier: GPL-3.0-or-later
+
+==> Mongoose License <==
+    Mongoose, Copyright 2018-2022, Timothy A. Davis, Scott P. Kolodziej,
+    William W. Hager, S. Nuri Yeralan
+    Licensed under the GNU GENERAL PUBLIC LICENSE, Version 3, 29 June 2007
+
+==> Example License <==
+
+Example package, Copyright (c), 2022, Timothy A. Davis, All Rights Reserved.
+SPDX-License-Identifier: BSD-3-clause
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+        * Redistributions of source code must retain the above copyright
+          notice, this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above copyright
+          notice, this list of conditions and the following disclaimer in the
+          documentation and/or other materials provided with the distribution.
+        * Neither the name of the organizations to which the authors are
+          affiliated, nor the names of its contributors may be used to endorse
+          or promote products derived from this software without specific prior
+          written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+    OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+    DAMAGE.
+""")
+
 jll = JLLInfo(;
     name = "SuiteSparse",
     version = v"7.2.0+1",
@@ -133,7 +1173,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [suitesparse_license],
         ),
 
         JLLBuildInfo(;
@@ -267,7 +1308,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [suitesparse_license],
         ),
 
         JLLBuildInfo(;
@@ -401,7 +1443,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [suitesparse_license],
         ),
 
         JLLBuildInfo(;
@@ -535,7 +1578,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [suitesparse_license],
         ),
 
         JLLBuildInfo(;
@@ -669,7 +1713,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [suitesparse_license],
         ),
 
         JLLBuildInfo(;
@@ -803,7 +1848,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [suitesparse_license],
         ),
 
         JLLBuildInfo(;
@@ -937,7 +1983,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [suitesparse_license],
         ),
 
         JLLBuildInfo(;
@@ -1071,7 +2118,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [suitesparse_license],
         ),
 
         JLLBuildInfo(;
@@ -1205,7 +2253,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [suitesparse_license],
         ),
 
         JLLBuildInfo(;
@@ -1339,7 +2388,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [suitesparse_license],
         ),
 
         JLLBuildInfo(;
@@ -1473,7 +2523,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [suitesparse_license],
         ),
 
         JLLBuildInfo(;
@@ -1607,7 +2658,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [suitesparse_license],
         ),
 
         JLLBuildInfo(;
@@ -1741,7 +2793,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [suitesparse_license],
         ),
 
         JLLBuildInfo(;
@@ -1875,7 +2928,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [suitesparse_license],
         ),
 
         JLLBuildInfo(;
@@ -2009,7 +3063,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [suitesparse_license],
         ),
 
         JLLBuildInfo(;
@@ -2143,7 +3198,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [suitesparse_license],
         ),
 
         JLLBuildInfo(;
@@ -2277,7 +3333,8 @@ jll = JLLInfo(;
                     ],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [suitesparse_license],
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/stdlib_jllinfos/Zlib_jll.jl
+++ b/JLLGenerator.jl/contrib/stdlib_jllinfos/Zlib_jll.jl
@@ -1,3 +1,124 @@
+zlib_license = JLLBuildLicense("LICENSE.md", """
+ZLIB DATA COMPRESSION LIBRARY
+
+zlib 1.2.13 is a general purpose data compression library.  All the code is
+thread safe.  The data format used by the zlib library is described by RFCs
+(Request for Comments) 1950 to 1952 in the files
+http://tools.ietf.org/html/rfc1950 (zlib format), rfc1951 (deflate format) and
+rfc1952 (gzip format).
+
+All functions of the compression library are documented in the file zlib.h
+(volunteer to write man pages welcome, contact zlib@gzip.org).  A usage example
+of the library is given in the file test/example.c which also tests that
+the library is working correctly.  Another example is given in the file
+test/minigzip.c.  The compression library itself is composed of all source
+files in the root directory.
+
+To compile all files and run the test program, follow the instructions given at
+the top of Makefile.in.  In short "./configure; make test", and if that goes
+well, "make install" should work for most flavors of Unix.  For Windows, use
+one of the special makefiles in win32/ or contrib/vstudio/ .  For VMS, use
+make_vms.com.
+
+Questions about zlib should be sent to <zlib@gzip.org>, or to Gilles Vollant
+<info@winimage.com> for the Windows DLL version.  The zlib home page is
+http://zlib.net/ .  Before reporting a problem, please check this site to
+verify that you have the latest version of zlib; otherwise get the latest
+version and check whether the problem still exists or not.
+
+PLEASE read the zlib FAQ http://zlib.net/zlib_faq.html before asking for help.
+
+Mark Nelson <markn@ieee.org> wrote an article about zlib for the Jan.  1997
+issue of Dr.  Dobb's Journal; a copy of the article is available at
+http://marknelson.us/1997/01/01/zlib-engine/ .
+
+The changes made in version 1.2.13 are documented in the file ChangeLog.
+
+Unsupported third party contributions are provided in directory contrib/ .
+
+zlib is available in Java using the java.util.zip package, documented at
+http://java.sun.com/developer/technicalArticles/Programming/compression/ .
+
+A Perl interface to zlib written by Paul Marquess <pmqs@cpan.org> is available
+at CPAN (Comprehensive Perl Archive Network) sites, including
+http://search.cpan.org/~pmqs/IO-Compress-Zlib/ .
+
+A Python interface to zlib written by A.M. Kuchling <amk@amk.ca> is
+available in Python 1.5 and later versions, see
+http://docs.python.org/library/zlib.html .
+
+zlib is built into tcl: http://wiki.tcl.tk/4610 .
+
+An experimental package to read and write files in .zip format, written on top
+of zlib by Gilles Vollant <info@winimage.com>, is available in the
+contrib/minizip directory of zlib.
+
+
+Notes for some targets:
+
+- For Windows DLL versions, please see win32/DLL_FAQ.txt
+
+- For 64-bit Irix, deflate.c must be compiled without any optimization. With
+  -O, one libpng test fails. The test works in 32 bit mode (with the -n32
+  compiler flag). The compiler bug has been reported to SGI.
+
+- zlib doesn't work with gcc 2.6.3 on a DEC 3000/300LX under OSF/1 2.1 it works
+  when compiled with cc.
+
+- On Digital Unix 4.0D (formely OSF/1) on AlphaServer, the cc option -std1 is
+  necessary to get gzprintf working correctly. This is done by configure.
+
+- zlib doesn't work on HP-UX 9.05 with some versions of /bin/cc. It works with
+  other compilers. Use "make test" to check your compiler.
+
+- gzdopen is not supported on RISCOS or BEOS.
+
+- For PalmOs, see http://palmzlib.sourceforge.net/
+
+
+Acknowledgments:
+
+  The deflate format used by zlib was defined by Phil Katz.  The deflate and
+  zlib specifications were written by L.  Peter Deutsch.  Thanks to all the
+  people who reported problems and suggested various improvements in zlib; they
+  are too numerous to cite here.
+
+Copyright notice:
+
+ (C) 1995-2022 Jean-loup Gailly and Mark Adler
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Jean-loup Gailly        Mark Adler
+  jloup@gzip.org          madler@alumni.caltech.edu
+
+If you use the zlib library in a product, we would appreciate *not* receiving
+lengthy legal documents to sign.  The sources are provided for free but without
+warranty of any kind.  The library has been entirely written by Jean-loup
+Gailly and Mark Adler; it does not include third-party code.  We make all
+contributions to and distributions of this project solely in our personal
+capacity, and are not conveying any rights to any intellectual property of
+any third parties.
+
+If you redistribute modified sources, we would appreciate that you include in
+the file ChangeLog history information documenting your changes.  Please read
+the FAQ for more information on the distribution of modified source versions.
+""")
+
 jll = JLLInfo(;
     name = "Zlib",
     version = v"1.2.13+1",
@@ -22,7 +143,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [zlib_license],
         ),
 
         JLLBuildInfo(;
@@ -45,7 +167,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [zlib_license],
         ),
 
         JLLBuildInfo(;
@@ -68,7 +191,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [zlib_license],
         ),
 
         JLLBuildInfo(;
@@ -91,7 +215,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [zlib_license],
         ),
 
         JLLBuildInfo(;
@@ -114,7 +239,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [zlib_license],
         ),
 
         JLLBuildInfo(;
@@ -137,7 +263,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [zlib_license],
         ),
 
         JLLBuildInfo(;
@@ -160,7 +287,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [zlib_license],
         ),
 
         JLLBuildInfo(;
@@ -183,7 +311,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [zlib_license],
         ),
 
         JLLBuildInfo(;
@@ -206,7 +335,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [zlib_license],
         ),
 
         JLLBuildInfo(;
@@ -229,7 +359,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [zlib_license],
         ),
 
         JLLBuildInfo(;
@@ -252,7 +383,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [zlib_license],
         ),
 
         JLLBuildInfo(;
@@ -275,7 +407,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [zlib_license],
         ),
 
         JLLBuildInfo(;
@@ -298,7 +431,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [zlib_license],
         ),
 
         JLLBuildInfo(;
@@ -321,7 +455,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [zlib_license],
         ),
 
         JLLBuildInfo(;
@@ -344,7 +479,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [zlib_license],
         ),
 
         JLLBuildInfo(;
@@ -367,7 +503,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [zlib_license],
         ),
 
         JLLBuildInfo(;
@@ -390,7 +527,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [zlib_license],
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/stdlib_jllinfos/dSFMT_jll.jl
+++ b/JLLGenerator.jl/contrib/stdlib_jllinfos/dSFMT_jll.jl
@@ -1,3 +1,38 @@
+dsfmt_license = JLLBuildLicense("LICENSE.md", """
+Copyright (c) 2007, 2008, 2009 Mutsuo Saito, Makoto Matsumoto
+and Hiroshima University.
+Copyright (c) 2011, 2002 Mutsuo Saito, Makoto Matsumoto, Hiroshima
+University and The University of Tokyo.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of the Hiroshima University nor the names of
+      its contributors may be used to endorse or promote products
+      derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+""")
+
 jll = JLLInfo(;
     name = "dSFMT",
     version = v"2.2.4+4",
@@ -24,7 +59,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [dsfmt_license],
         ),
 
         JLLBuildInfo(;
@@ -49,7 +85,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [dsfmt_license],
         ),
 
         JLLBuildInfo(;
@@ -74,7 +111,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [dsfmt_license],
         ),
 
         JLLBuildInfo(;
@@ -99,7 +137,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [dsfmt_license],
         ),
 
         JLLBuildInfo(;
@@ -124,7 +163,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [dsfmt_license],
         ),
 
         JLLBuildInfo(;
@@ -149,7 +189,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [dsfmt_license],
         ),
 
         JLLBuildInfo(;
@@ -174,7 +215,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [dsfmt_license],
         ),
 
         JLLBuildInfo(;
@@ -199,7 +241,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [dsfmt_license],
         ),
 
         JLLBuildInfo(;
@@ -224,7 +267,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [dsfmt_license],
         ),
 
         JLLBuildInfo(;
@@ -249,7 +293,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [dsfmt_license],
         ),
 
         JLLBuildInfo(;
@@ -274,7 +319,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [dsfmt_license],
         ),
 
         JLLBuildInfo(;
@@ -299,7 +345,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [dsfmt_license],
         ),
 
         JLLBuildInfo(;
@@ -324,7 +371,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [dsfmt_license],
         ),
 
         JLLBuildInfo(;
@@ -349,7 +397,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [dsfmt_license],
         ),
 
         JLLBuildInfo(;
@@ -374,7 +423,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [dsfmt_license],
         ),
 
         JLLBuildInfo(;
@@ -399,7 +449,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [dsfmt_license],
         ),
 
         JLLBuildInfo(;
@@ -424,7 +475,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [dsfmt_license],
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/stdlib_jllinfos/libLLVM_jll.jl
+++ b/JLLGenerator.jl/contrib/stdlib_jllinfos/libLLVM_jll.jl
@@ -1,3 +1,5 @@
+Base.include(@__MODULE__, joinpath(@__DIR__, "llvm_license.jl"))
+
 jll = JLLInfo(;
     name = "libLLVM",
     version = v"15.0.7+8",
@@ -41,7 +43,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -83,7 +86,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -125,7 +129,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -167,7 +172,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -209,7 +215,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -251,7 +258,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -293,7 +301,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -335,7 +344,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -377,7 +387,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -419,7 +430,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -461,7 +473,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -503,7 +516,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -545,7 +559,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -587,7 +602,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -629,7 +645,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -671,7 +688,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -713,7 +731,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -755,7 +774,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -797,7 +817,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -839,7 +860,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -881,7 +903,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -923,7 +946,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -965,7 +989,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1007,7 +1032,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1049,7 +1075,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1091,7 +1118,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1133,7 +1161,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1175,7 +1204,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1217,7 +1247,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1259,7 +1290,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1301,7 +1333,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools\\llvm-config.exe",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1343,7 +1376,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools\\llvm-config.exe",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1385,7 +1419,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools\\llvm-config.exe",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1427,7 +1462,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools\\llvm-config.exe",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1469,7 +1505,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1511,7 +1548,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1553,7 +1591,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1595,7 +1634,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1637,7 +1677,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1679,7 +1720,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1721,7 +1763,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1763,7 +1806,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1805,7 +1849,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1847,7 +1892,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1889,7 +1935,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1931,7 +1978,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -1973,7 +2021,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -2015,7 +2064,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -2057,7 +2107,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -2099,7 +2150,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -2141,7 +2193,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -2183,7 +2236,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools/llvm-config",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -2225,7 +2279,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools\\llvm-config.exe",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -2267,7 +2322,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools\\llvm-config.exe",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -2309,7 +2365,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools\\llvm-config.exe",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
         JLLBuildInfo(;
@@ -2351,7 +2408,8 @@ jll = JLLInfo(;
                     :llvm_config,
                     "tools\\llvm-config.exe",
                 ),
-            ]
+            ],
+            licenses = [llvm_license],
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/stdlib_jllinfos/libblastrampoline_jll.jl
+++ b/JLLGenerator.jl/contrib/stdlib_jllinfos/libblastrampoline_jll.jl
@@ -6,6 +6,7 @@ function libblastrampoline_on_load_callback()
     end
 end
 """
+lbt_license = JLLBuildLicense("LICENSE.md", JLLGenerator.get_license_text("MIT"))
 
 jll = JLLInfo(;
     name = "libblastrampoline",
@@ -38,7 +39,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libblastrampoline_on_load_callback => on_load_callback_def,
-            )
+            ),
+            licenses = [lbt_license],
         ),
 
         JLLBuildInfo(;
@@ -68,7 +70,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libblastrampoline_on_load_callback => on_load_callback_def,
-            )
+            ),
+            licenses = [lbt_license],
         ),
 
         JLLBuildInfo(;
@@ -98,7 +101,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libblastrampoline_on_load_callback => on_load_callback_def,
-            )
+            ),
+            licenses = [lbt_license],
         ),
 
         JLLBuildInfo(;
@@ -128,7 +132,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libblastrampoline_on_load_callback => on_load_callback_def,
-            )
+            ),
+            licenses = [lbt_license],
         ),
 
         JLLBuildInfo(;
@@ -158,7 +163,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libblastrampoline_on_load_callback => on_load_callback_def,
-            )
+            ),
+            licenses = [lbt_license],
         ),
 
         JLLBuildInfo(;
@@ -188,7 +194,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libblastrampoline_on_load_callback => on_load_callback_def,
-            )
+            ),
+            licenses = [lbt_license],
         ),
 
         JLLBuildInfo(;
@@ -218,7 +225,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libblastrampoline_on_load_callback => on_load_callback_def,
-            )
+            ),
+            licenses = [lbt_license],
         ),
 
         JLLBuildInfo(;
@@ -248,7 +256,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libblastrampoline_on_load_callback => on_load_callback_def,
-            )
+            ),
+            licenses = [lbt_license],
         ),
 
         JLLBuildInfo(;
@@ -278,7 +287,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libblastrampoline_on_load_callback => on_load_callback_def,
-            )
+            ),
+            licenses = [lbt_license],
         ),
 
         JLLBuildInfo(;
@@ -308,7 +318,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libblastrampoline_on_load_callback => on_load_callback_def,
-            )
+            ),
+            licenses = [lbt_license],
         ),
 
         JLLBuildInfo(;
@@ -338,7 +349,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libblastrampoline_on_load_callback => on_load_callback_def,
-            )
+            ),
+            licenses = [lbt_license],
         ),
 
         JLLBuildInfo(;
@@ -368,7 +380,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libblastrampoline_on_load_callback => on_load_callback_def,
-            )
+            ),
+            licenses = [lbt_license],
         ),
 
         JLLBuildInfo(;
@@ -398,7 +411,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libblastrampoline_on_load_callback => on_load_callback_def,
-            )
+            ),
+            licenses = [lbt_license],
         ),
 
         JLLBuildInfo(;
@@ -428,7 +442,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libblastrampoline_on_load_callback => on_load_callback_def,
-            )
+            ),
+            licenses = [lbt_license],
         ),
 
         JLLBuildInfo(;
@@ -458,7 +473,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libblastrampoline_on_load_callback => on_load_callback_def,
-            )
+            ),
+            licenses = [lbt_license],
         ),
 
         JLLBuildInfo(;
@@ -488,7 +504,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libblastrampoline_on_load_callback => on_load_callback_def,
-            )
+            ),
+            licenses = [lbt_license],
         ),
 
         JLLBuildInfo(;
@@ -518,7 +535,8 @@ jll = JLLInfo(;
             ],
             callback_defs = Dict(
                 :libblastrampoline_on_load_callback => on_load_callback_def,
-            )
+            ),
+            licenses = [lbt_license],
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/stdlib_jllinfos/llvm_license.jl
+++ b/JLLGenerator.jl/contrib/stdlib_jllinfos/llvm_license.jl
@@ -1,0 +1,280 @@
+llvm_license = JLLBuildLicense("LICENSE.md", """
+==============================================================================
+The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:
+==============================================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+---- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+
+==============================================================================
+Software from third parties included in the LLVM Project:
+==============================================================================
+The LLVM Project contains third party software which is under different license
+terms. All such code will be identified clearly using at least one of two
+mechanisms:
+1) It will be in a separate directory tree with its own `LICENSE.txt` or
+   `LICENSE` file at the top containing the specific license and restrictions
+   which apply to that software, or
+2) It will contain specific license and restriction terms at the top of every
+   file.
+
+==============================================================================
+Legacy LLVM License (https://llvm.org/docs/DeveloperPolicy.html#legacy):
+==============================================================================
+University of Illinois/NCSA
+Open Source License
+
+Copyright (c) 2003-2019 University of Illinois at Urbana-Champaign.
+All rights reserved.
+
+Developed by:
+
+    LLVM Team
+
+    University of Illinois at Urbana-Champaign
+
+    http://llvm.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal with
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimers.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimers in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the names of the LLVM Team, University of Illinois at
+      Urbana-Champaign, nor the names of its contributors may be used to
+      endorse or promote products derived from this Software without specific
+      prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+SOFTWARE.
+""")

--- a/JLLGenerator.jl/contrib/stdlib_jllinfos/nghttp2_jll.jl
+++ b/JLLGenerator.jl/contrib/stdlib_jllinfos/nghttp2_jll.jl
@@ -1,3 +1,4 @@
+nghttp_license = JLLBuildLicense("LICENSE.md", JLLGenerator.get_license_text("MIT"))
 jll = JLLInfo(;
     name = "nghttp2",
     version = v"1.52.0+1",
@@ -25,7 +26,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [nghttp_license],
         ),
 
         JLLBuildInfo(;
@@ -51,7 +53,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [nghttp_license],
         ),
 
         JLLBuildInfo(;
@@ -77,7 +80,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [nghttp_license],
         ),
 
         JLLBuildInfo(;
@@ -103,7 +107,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [nghttp_license],
         ),
 
         JLLBuildInfo(;
@@ -129,7 +134,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [nghttp_license],
         ),
 
         JLLBuildInfo(;
@@ -155,7 +161,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [nghttp_license],
         ),
 
         JLLBuildInfo(;
@@ -181,7 +188,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [nghttp_license],
         ),
 
         JLLBuildInfo(;
@@ -207,7 +215,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [nghttp_license],
         ),
 
         JLLBuildInfo(;
@@ -233,7 +242,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [nghttp_license],
         ),
 
         JLLBuildInfo(;
@@ -259,7 +269,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [nghttp_license],
         ),
 
         JLLBuildInfo(;
@@ -285,7 +296,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [nghttp_license],
         ),
 
         JLLBuildInfo(;
@@ -311,7 +323,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [nghttp_license],
         ),
 
         JLLBuildInfo(;
@@ -337,7 +350,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [nghttp_license],
         ),
 
         JLLBuildInfo(;
@@ -363,7 +377,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [nghttp_license],
         ),
 
         JLLBuildInfo(;
@@ -389,7 +404,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [nghttp_license],
         ),
 
         JLLBuildInfo(;
@@ -415,7 +431,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [nghttp_license],
         ),
 
         JLLBuildInfo(;
@@ -441,7 +458,8 @@ jll = JLLInfo(;
                     [],
                     flags = [:RTLD_LAZY, :RTLD_DEEPBIND],
                 ),
-            ]
+            ],
+            licenses = [nghttp_license],
         ),
 
     ]

--- a/JLLGenerator.jl/contrib/stdlib_jllinfos/p7zip_jll.jl
+++ b/JLLGenerator.jl/contrib/stdlib_jllinfos/p7zip_jll.jl
@@ -1,3 +1,59 @@
+p7zip_license = JLLBuildLicense("LICENSE.md", """
+  7-Zip source code
+  ~~~~~~~~~~~~~~~~~
+  License for use and distribution
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  7-Zip Copyright (C) 1999-2016 Igor Pavlov.
+
+  Licenses for files are:
+
+    1) CPP/7zip/Compress/Rar* files:  GNU LGPL + unRAR restriction
+    2) All other files:  GNU LGPL
+
+  The GNU LGPL + unRAR restriction means that you must follow both 
+  GNU LGPL rules and unRAR restriction rules.
+
+
+  GNU LGPL information
+  --------------------
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+    USA
+
+
+  unRAR restriction
+  -----------------
+
+    The decompression engine for RAR archives was developed using source 
+    code of unRAR program.
+    All copyrights to original unRAR code are owned by Alexander Roshal.
+
+    The license for original unRAR code has the following restriction:
+
+    The unRAR sources cannot be used to re-create the RAR compression algorithm, 
+    which is proprietary. Distribution of modified unRAR sources in separate form 
+    or as a part of other software is permitted, provided that it is clearly
+    stated in the documentation and source comments that the code may
+    not be used to develop a RAR (WinRAR) compatible archiver.
+
+
+  --
+  Igor Pavlov
+""")
+
 jll = JLLInfo(;
     name = "p7zip",
     version = v"17.4.0+2",
@@ -23,7 +79,8 @@ jll = JLLInfo(;
                     :p7zip,
                     "bin/7z",
                 ),
-            ]
+            ],
+            licenses = [p7zip_license],
         ),
 
         JLLBuildInfo(;
@@ -47,7 +104,8 @@ jll = JLLInfo(;
                     :p7zip,
                     "bin/7z",
                 ),
-            ]
+            ],
+            licenses = [p7zip_license],
         ),
 
         JLLBuildInfo(;
@@ -71,7 +129,8 @@ jll = JLLInfo(;
                     :p7zip,
                     "bin/7z",
                 ),
-            ]
+            ],
+            licenses = [p7zip_license],
         ),
 
         JLLBuildInfo(;
@@ -95,7 +154,8 @@ jll = JLLInfo(;
                     :p7zip,
                     "bin/7z",
                 ),
-            ]
+            ],
+            licenses = [p7zip_license],
         ),
 
         JLLBuildInfo(;
@@ -119,7 +179,8 @@ jll = JLLInfo(;
                     :p7zip,
                     "bin/7z",
                 ),
-            ]
+            ],
+            licenses = [p7zip_license],
         ),
 
         JLLBuildInfo(;
@@ -143,7 +204,8 @@ jll = JLLInfo(;
                     :p7zip,
                     "bin/7z",
                 ),
-            ]
+            ],
+            licenses = [p7zip_license],
         ),
 
         JLLBuildInfo(;
@@ -167,7 +229,8 @@ jll = JLLInfo(;
                     :p7zip,
                     "bin/7z",
                 ),
-            ]
+            ],
+            licenses = [p7zip_license],
         ),
 
         JLLBuildInfo(;
@@ -191,7 +254,8 @@ jll = JLLInfo(;
                     :p7zip,
                     "bin/7z",
                 ),
-            ]
+            ],
+            licenses = [p7zip_license],
         ),
 
         JLLBuildInfo(;
@@ -215,7 +279,8 @@ jll = JLLInfo(;
                     :p7zip,
                     "bin/7z",
                 ),
-            ]
+            ],
+            licenses = [p7zip_license],
         ),
 
         JLLBuildInfo(;
@@ -239,7 +304,8 @@ jll = JLLInfo(;
                     :p7zip,
                     "bin\\7z.exe",
                 ),
-            ]
+            ],
+            licenses = [p7zip_license],
         ),
 
         JLLBuildInfo(;
@@ -263,7 +329,8 @@ jll = JLLInfo(;
                     :p7zip,
                     "bin/7z",
                 ),
-            ]
+            ],
+            licenses = [p7zip_license],
         ),
 
         JLLBuildInfo(;
@@ -287,7 +354,8 @@ jll = JLLInfo(;
                     :p7zip,
                     "bin/7z",
                 ),
-            ]
+            ],
+            licenses = [p7zip_license],
         ),
 
         JLLBuildInfo(;
@@ -311,7 +379,8 @@ jll = JLLInfo(;
                     :p7zip,
                     "bin/7z",
                 ),
-            ]
+            ],
+            licenses = [p7zip_license],
         ),
 
         JLLBuildInfo(;
@@ -335,7 +404,8 @@ jll = JLLInfo(;
                     :p7zip,
                     "bin/7z",
                 ),
-            ]
+            ],
+            licenses = [p7zip_license],
         ),
 
         JLLBuildInfo(;
@@ -359,7 +429,8 @@ jll = JLLInfo(;
                     :p7zip,
                     "bin/7z",
                 ),
-            ]
+            ],
+            licenses = [p7zip_license],
         ),
 
         JLLBuildInfo(;
@@ -383,7 +454,8 @@ jll = JLLInfo(;
                     :p7zip,
                     "bin/7z",
                 ),
-            ]
+            ],
+            licenses = [p7zip_license],
         ),
 
         JLLBuildInfo(;
@@ -407,7 +479,8 @@ jll = JLLInfo(;
                     :p7zip,
                     "bin\\7z.exe",
                 ),
-            ]
+            ],
+            licenses = [p7zip_license],
         ),
 
     ]

--- a/JLLGenerator.jl/src/LicenseTexts.jl
+++ b/JLLGenerator.jl/src/LicenseTexts.jl
@@ -1,0 +1,13 @@
+const license_texts = Dict{String,String}()
+
+# NOTE: Adding a new license 
+for license_name in readdir(joinpath(@__DIR__, "license_raw_texts"))
+    license_texts[license_name] = String(read(joinpath(@__DIR__, "license_raw_texts", license_name)))
+end
+
+function get_license_text(license_name::String)
+    if !haskey(license_texts, license_name)
+        throw(ArgumentError("We do not have $(license_name) as a vendored license blob yet!"))
+    end
+    return license_texts[license_name]
+end

--- a/JLLGenerator.jl/src/license_raw_texts/AGPL-3.0
+++ b/JLLGenerator.jl/src/license_raw_texts/AGPL-3.0
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/JLLGenerator.jl/src/license_raw_texts/Apache-2.0
+++ b/JLLGenerator.jl/src/license_raw_texts/Apache-2.0
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/JLLGenerator.jl/src/license_raw_texts/GPL-2.0
+++ b/JLLGenerator.jl/src/license_raw_texts/GPL-2.0
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/JLLGenerator.jl/src/license_raw_texts/GPL-3.0
+++ b/JLLGenerator.jl/src/license_raw_texts/GPL-3.0
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/JLLGenerator.jl/src/license_raw_texts/LGPL-3.0
+++ b/JLLGenerator.jl/src/license_raw_texts/LGPL-3.0
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/JLLGenerator.jl/src/license_raw_texts/MIT
+++ b/JLLGenerator.jl/src/license_raw_texts/MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/JLLGenerator.jl/src/license_raw_texts/MPL-2.0
+++ b/JLLGenerator.jl/src/license_raw_texts/MPL-2.0
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.


### PR DESCRIPTION
This adds a `JLLBuildLicense` object, a vector of which is attached to each `JLLBuild`.  It stores the filename the license should be written out to, the full text of the license, and the SPDX identifier of the license, if it is recognized by `LicenseCheck`.