### PR TITLE
Universe rework

### DIFF
--- a/.buildkite/run_bb_tests.yml
+++ b/.buildkite/run_bb_tests.yml
@@ -1,6 +1,10 @@
 steps:
   - label: ":julia: :linux: ${ARCH?} Julia ${JULIA_VERSION?}"
     plugins:
+      - staticfloat/metahook:
+          post-checkout: |
+            git config --global user.email "buildkite@julialang.org"
+            git config --global user.name "Buildkite"
       - JuliaCI/julia#v1:
           version: "${JULIA_VERSION?}"
           arch: "${ARCH?}"

--- a/BinaryBuilderAuditor.jl/Manifest.toml
+++ b/BinaryBuilderAuditor.jl/Manifest.toml
@@ -29,7 +29,7 @@ uuid = "654d7472-7548-7361-4832-74694762694c"
 version = "0.1.1"
 
 [[deps.BinaryBuilderPlatformExtensions]]
-deps = ["OrderedCollections", "Reexport"]
+deps = ["OrderedCollections", "PrecompileTools", "Reexport"]
 path = "../BinaryBuilderPlatformExtensions.jl"
 uuid = "213f2928-4d72-6f46-7461-4c705f634367"
 version = "0.1.0"
@@ -47,7 +47,7 @@ uuid = "316c416d-4527-6863-7465-466137743047"
 version = "0.1.0"
 
 [[deps.BinaryBuilderToolchains]]
-deps = ["Artifacts", "BinaryBuilderPlatformExtensions", "BinaryBuilderSources", "HistoricalStdlibVersions", "JLLPrefixes", "NetworkOptions", "Pkg", "Reexport", "SHA", "Scratch"]
+deps = ["Artifacts", "BinaryBuilderPlatformExtensions", "BinaryBuilderSources", "HistoricalStdlibVersions", "JLLPrefixes", "NetworkOptions", "Pkg", "PrecompileTools", "Reexport", "SHA", "Scratch"]
 path = "../BinaryBuilderToolchains.jl"
 uuid = "33566f4c-336c-3150-6d30-4374274e6143"
 version = "0.2.0"
@@ -253,6 +253,12 @@ version = "1.11.0"
 
     [deps.Pkg.weakdeps]
     REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.2.1"
 
 [[deps.Preferences]]
 deps = ["TOML"]

--- a/BinaryBuilderProducts.jl/Manifest.toml
+++ b/BinaryBuilderProducts.jl/Manifest.toml
@@ -29,7 +29,7 @@ uuid = "654d7472-7548-7361-4832-74694762694c"
 version = "0.1.1"
 
 [[deps.BinaryBuilderPlatformExtensions]]
-deps = ["OrderedCollections", "Reexport"]
+deps = ["OrderedCollections", "PrecompileTools", "Reexport"]
 path = "../BinaryBuilderPlatformExtensions.jl"
 uuid = "213f2928-4d72-6f46-7461-4c705f634367"
 version = "0.1.0"
@@ -224,6 +224,12 @@ version = "1.11.0"
 
     [deps.Pkg.weakdeps]
     REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.2.1"
 
 [[deps.Preferences]]
 deps = ["TOML"]

--- a/BinaryBuilderToolchains.jl/test/CMakeToolchainTests.jl
+++ b/BinaryBuilderToolchains.jl/test/CMakeToolchainTests.jl
@@ -1,8 +1,6 @@
 using Test, BinaryBuilderToolchains
 using BinaryBuilderToolchains: path_appending_merge
 
-include("common.jl")
-
 @testset "CMakeToolchain" begin
     platform = CrossPlatform(BBHostPlatform() => BBHostPlatform())
     toolchains = [

--- a/BinaryBuilderToolchains.jl/test/CToolchainTests.jl
+++ b/BinaryBuilderToolchains.jl/test/CToolchainTests.jl
@@ -4,8 +4,6 @@ using BinaryBuilderToolchains: path_appending_merge
 # Enable this for lots of JLLPrefixes output
 const verbose = false
 
-include("common.jl")
-
 using BinaryBuilderToolchains: get_vendor
 @testset "CToolchain" begin
     # Use native compilers so that we can run the output.

--- a/BinaryBuilderToolchains.jl/test/runtests.jl
+++ b/BinaryBuilderToolchains.jl/test/runtests.jl
@@ -1,5 +1,6 @@
 using Test, BinaryBuilderToolchains
 
+include("common.jl")
 include("PkgUtilsTests.jl")
 include("WrapperUtilsTests.jl")
 include("CToolchainTestJLLs.jl")

--- a/BinaryBuilderToolchains.jl/test/testsuite/CToolchain/08_strip_resigning/Makefile
+++ b/BinaryBuilderToolchains.jl/test/testsuite/CToolchain/08_strip_resigning/Makefile
@@ -21,7 +21,7 @@ endif
 
 RUN_IDX := 0
 define run_strip
-RUN_IDX := $(shell echo "$(RUN_IDX) + 1" | bc)
+RUN_IDX := $(shell bash -c "echo $$(($(RUN_IDX) + 1))")
 TARGET_$(RUN_IDX)_PATH := $$(PROJECT_DIR)/build/count_dracula.stripped$(subst $(SPACE),,$(1))
 $$(TARGET_$(RUN_IDX)_PATH).direct: $$(COUNT_DRACULA) | $(PROJECT_DIR)/build
 	@cp $$^ $$@

--- a/BinaryBuilderToolchains.jl/test/testsuite/CToolchain/common.mk
+++ b/BinaryBuilderToolchains.jl/test/testsuite/CToolchain/common.mk
@@ -31,11 +31,12 @@ endif
 
 # Define some compiler defaults (they are typically overridden by `export`'ed
 # variables in the BB shell)
-CC ?= $(target)-cc
-CXX ?= $(target)-c++
-AR ?= $(target)-ar
-RANLIB ?= $(target)-ranlib
-OBJCOPY ?= $(target)-objcopy
+CC ?= $(CC_TARGET)-cc
+CXX ?= $(CC_TARGET)-c++
+AR ?= $(CC_TARGET)-ar
+RANLIB ?= $(CC_TARGET)-ranlib
+OBJCOPY ?= $(CC_TARGET)-objcopy
+STRIP ?= $(CC_TARGET)-strip
 
 # Magic variables
 SPACE:=$(eval) $(eval)

--- a/JLLGenerator.jl/Manifest.toml
+++ b/JLLGenerator.jl/Manifest.toml
@@ -17,7 +17,7 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 version = "1.11.0"
 
 [[deps.BinaryBuilderPlatformExtensions]]
-deps = ["OrderedCollections", "Reexport"]
+deps = ["OrderedCollections", "PrecompileTools", "Reexport"]
 path = "../BinaryBuilderPlatformExtensions.jl"
 uuid = "213f2928-4d72-6f46-7461-4c705f634367"
 version = "0.1.0"
@@ -133,6 +133,12 @@ version = "1.11.0"
 
     [deps.Pkg.weakdeps]
     REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.2.1"
 
 [[deps.Preferences]]
 deps = ["TOML"]

--- a/JLLGenerator.jl/contrib/Manifest.toml
+++ b/JLLGenerator.jl/contrib/Manifest.toml
@@ -19,7 +19,7 @@ uuid = "654d7472-7548-7361-4832-74694762694c"
 version = "0.1.1"
 
 [[deps.BinaryBuilderPlatformExtensions]]
-deps = ["OrderedCollections", "Reexport"]
+deps = ["OrderedCollections", "PrecompileTools", "Reexport"]
 path = "../../BinaryBuilderPlatformExtensions.jl"
 uuid = "213f2928-4d72-6f46-7461-4c705f634367"
 version = "0.1.0"
@@ -113,6 +113,12 @@ version = "1.7.0"
 deps = ["Artifacts", "Libdl"]
 uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
 version = "10.42.0+1"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.2.1"
 
 [[deps.Preferences]]
 deps = ["TOML"]

--- a/Manifest-v1.12.toml
+++ b/Manifest-v1.12.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.0-DEV"
 manifest_format = "2.0"
-project_hash = "22b0cea6bc21f11cf9401efdfc4149999d2f287f"
+project_hash = "cdfe2b9472493a34860c69a3b0ca1b4c4e5f639e"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
@@ -41,7 +41,7 @@ uuid = "654d7472-7548-7361-4832-74694762694c"
 version = "0.1.1"
 
 [[deps.BinaryBuilderPlatformExtensions]]
-deps = ["OrderedCollections", "Reexport"]
+deps = ["OrderedCollections", "PrecompileTools", "Reexport"]
 path = "BinaryBuilderPlatformExtensions.jl"
 uuid = "213f2928-4d72-6f46-7461-4c705f634367"
 version = "0.1.0"
@@ -59,7 +59,7 @@ uuid = "316c416d-4527-6863-7465-466137743047"
 version = "0.1.0"
 
 [[deps.BinaryBuilderToolchains]]
-deps = ["Artifacts", "BinaryBuilderPlatformExtensions", "BinaryBuilderSources", "HistoricalStdlibVersions", "JLLPrefixes", "NetworkOptions", "Pkg", "Reexport", "SHA", "Scratch"]
+deps = ["Artifacts", "BinaryBuilderPlatformExtensions", "BinaryBuilderSources", "HistoricalStdlibVersions", "JLLPrefixes", "NetworkOptions", "Pkg", "PrecompileTools", "Reexport", "SHA", "Scratch"]
 path = "BinaryBuilderToolchains.jl"
 uuid = "33566f4c-336c-3150-6d30-4374274e6143"
 version = "0.2.0"
@@ -105,9 +105,9 @@ version = "1.0.4"
 
 [[deps.Expat_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "e51db81749b0777b2147fbe7b783ee79045b8e99"
+git-tree-sha1 = "d55dffd9ae73ff72f1c0482454dcf2ec6c6c4a63"
 uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
-version = "2.6.4+3"
+version = "2.6.5+0"
 
 [[deps.ExprTools]]
 git-tree-sha1 = "27415f162e6028e81c72b82ef756bf321213b6ec"
@@ -131,12 +131,12 @@ uuid = "f8c6e375-362e-5223-8a59-34ff63f689eb"
 version = "2.44.0+2"
 
 [[deps.HistoricalStdlibVersions]]
-deps = ["Pkg"]
-git-tree-sha1 = "fc8e78e29ecfdc7da3cfc290fa0d4a67e1915958"
+deps = ["Pkg", "PrecompileTools"]
+git-tree-sha1 = "ab6fc1fd927d3c95a8357ef7c98859bcb0611478"
 repo-rev = "main"
 repo-url = "https://github.com/JuliaPackaging/HistoricalStdlibVersions.jl.git"
 uuid = "6df8b67a-e8a0-4029-b4b7-ac196fe72102"
-version = "2.0.1"
+version = "2.0.3"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
@@ -271,7 +271,7 @@ version = "0.4.3"
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.0.15+2"
+version = "3.0.16+0"
 
 [[deps.OrderedCollections]]
 git-tree-sha1 = "cc4054e898b852042d7b503313f7ad03de99c3dd"
@@ -307,6 +307,12 @@ version = "1.12.0"
 
     [deps.Pkg.weakdeps]
     REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.2.1"
 
 [[deps.Preferences]]
 deps = ["TOML"]
@@ -399,9 +405,15 @@ version = "1.11.0"
 
 [[deps.TimerOutputs]]
 deps = ["ExprTools", "Printf"]
-git-tree-sha1 = "d7298ebdfa1654583468a487e8e83fae9d72dac3"
+git-tree-sha1 = "3832505b94c1868baea47764127e6d36b5c9f29e"
 uuid = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
-version = "0.5.26"
+version = "0.5.27"
+
+    [deps.TimerOutputs.extensions]
+    FlameGraphsExt = "FlameGraphs"
+
+    [deps.TimerOutputs.weakdeps]
+    FlameGraphs = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
 
 [[deps.TreeArchival]]
 deps = ["SHA", "Tar", "Tar_jll", "Zstd_jll", "p7zip_jll"]

--- a/Manifest-v1.13.toml
+++ b/Manifest-v1.13.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.11.3"
+julia_version = "1.13.0-DEV"
 manifest_format = "2.0"
-project_hash = "c2c0a9de51da846604f145b00627e6050ebdafbd"
+project_hash = "cdfe2b9472493a34860c69a3b0ca1b4c4e5f639e"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
@@ -21,6 +21,12 @@ version = "2.5.2+0"
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 version = "1.11.0"
+
+[[deps.BinaryBuilder2]]
+deps = ["Artifacts", "BinaryBuilderAuditor", "BinaryBuilderGitUtils", "BinaryBuilderPlatformExtensions", "BinaryBuilderProducts", "BinaryBuilderSources", "BinaryBuilderToolchains", "Ccache_jll", "Dates", "Downloads", "Git", "HistoricalStdlibVersions", "JLLGenerator", "JLLPrefixes", "KeywordArgumentExtraction", "LazyJLLWrappers", "Libdl", "LocalRegistry", "MultiHashParsing", "ObjectFile", "OrderedCollections", "OutputCollectors", "Pkg", "Preferences", "Random", "Reexport", "RegistryTools", "SHA", "Sandbox", "Scratch", "StyledStrings", "TOML", "Test", "TimerOutputs", "TreeArchival", "UserNSSandbox_jll", "gh_cli_jll"]
+path = "."
+uuid = "12aac903-9f7c-5d81-afc2-d9565ea332af"
+version = "2.0.0"
 
 [[deps.BinaryBuilderAuditor]]
 deps = ["BinaryBuilderProducts", "BinaryBuilderToolchains", "JLLGenerator", "ObjectFile", "Patchelf_jll", "StyledStrings"]
@@ -80,7 +86,7 @@ version = "4.16.0"
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.1.1+0"
+version = "1.3.0+1"
 
 [[deps.Dates]]
 deps = ["Printf"]
@@ -90,7 +96,7 @@ version = "1.11.0"
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
-version = "1.6.0"
+version = "1.7.0"
 
 [[deps.EnumX]]
 git-tree-sha1 = "bdb1942cd4c45e3c678fd11569d5cccd80976237"
@@ -120,9 +126,9 @@ version = "1.3.1"
 
 [[deps.Git_jll]]
 deps = ["Artifacts", "Expat_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "Libiconv_jll", "OpenSSL_jll", "PCRE2_jll", "Zlib_jll"]
-git-tree-sha1 = "399f4a308c804b446ae4c91eeafadb2fe2c54ff9"
+git-tree-sha1 = "d18fb8a1f3609361ebda9bf029b60fd0f120c809"
 uuid = "f8c6e375-362e-5223-8a59-34ff63f689eb"
-version = "2.47.1+0"
+version = "2.44.0+2"
 
 [[deps.HistoricalStdlibVersions]]
 deps = ["Pkg", "PrecompileTools"]
@@ -159,6 +165,11 @@ git-tree-sha1 = "a007feb38b422fbdab534406aeca1b86823cb4d6"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 version = "1.7.0"
 
+[[deps.JuliaSyntaxHighlighting]]
+deps = ["StyledStrings"]
+uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
+version = "1.12.0"
+
 [[deps.KeywordArgumentExtraction]]
 deps = ["ExprTools", "InteractiveUtils"]
 path = "KeywordArgumentExtraction.jl"
@@ -187,24 +198,24 @@ uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
 version = "0.6.4"
 
 [[deps.LibCURL_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "8.6.0+0"
+version = "8.11.1+1"
 
 [[deps.LibGit2]]
-deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 version = "1.11.0"
 
 [[deps.LibGit2_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll"]
 uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
-version = "1.7.2+0"
+version = "1.9.0+0"
 
 [[deps.LibSSH2_jll]]
-deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+deps = ["Artifacts", "Libdl", "OpenSSL_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
-version = "1.11.0+1"
+version = "1.11.3+1"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -233,18 +244,13 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 version = "1.11.0"
 
 [[deps.Markdown]]
-deps = ["Base64"]
+deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 version = "1.11.0"
 
-[[deps.MbedTLS_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.6+0"
-
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2023.12.12"
+version = "2024.12.31"
 
 [[deps.MultiHashParsing]]
 deps = ["SHA"]
@@ -254,7 +260,7 @@ version = "0.1.0"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
-version = "1.2.0"
+version = "1.3.0"
 
 [[deps.ObjectFile]]
 deps = ["Reexport", "StructIO"]
@@ -263,8 +269,7 @@ uuid = "d8793406-e978-5875-9003-1fc021f44a92"
 version = "0.4.3"
 
 [[deps.OpenSSL_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "a9697f1d06cc3eb3fb3ad49cc67f2cfabaac31ea"
+deps = ["Artifacts", "Libdl"]
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
 version = "3.0.16+0"
 
@@ -284,7 +289,7 @@ version = "1.0.0"
 [[deps.PCRE2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
-version = "10.42.0+1"
+version = "10.44.0+1"
 
 [[deps.Patchelf_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
@@ -295,7 +300,7 @@ version = "0.18.0+0"
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.11.0"
+version = "1.12.0"
 
     [deps.Pkg.extensions]
     REPLExt = "REPL"
@@ -434,13 +439,13 @@ version = "2025.1.28+0"
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.13+1"
+version = "1.3.1+2"
 
 [[deps.Zstd_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "446b23e73536f84e8037f5dce465e92275f6a308"
+git-tree-sha1 = "e678132f07ddb5bfa46857f0d7620fb9be675d3b"
 uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
-version = "1.5.7+1"
+version = "1.5.6+0"
 
 [[deps.gh_cli_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -457,9 +462,9 @@ version = "0.3.101+0"
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-version = "1.59.0+0"
+version = "1.64.0+1"
 
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.4.0+2"
+version = "17.5.0+2"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.11.3"
+julia_version = "1.13.0-DEV"
 manifest_format = "2.0"
-project_hash = "c2c0a9de51da846604f145b00627e6050ebdafbd"
+project_hash = "cdfe2b9472493a34860c69a3b0ca1b4c4e5f639e"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
@@ -21,6 +21,12 @@ version = "2.5.2+0"
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 version = "1.11.0"
+
+[[deps.BinaryBuilder2]]
+deps = ["Artifacts", "BinaryBuilderAuditor", "BinaryBuilderGitUtils", "BinaryBuilderPlatformExtensions", "BinaryBuilderProducts", "BinaryBuilderSources", "BinaryBuilderToolchains", "Ccache_jll", "Dates", "Downloads", "Git", "HistoricalStdlibVersions", "JLLGenerator", "JLLPrefixes", "KeywordArgumentExtraction", "LazyJLLWrappers", "Libdl", "LocalRegistry", "MultiHashParsing", "ObjectFile", "OrderedCollections", "OutputCollectors", "Pkg", "Preferences", "Random", "Reexport", "RegistryTools", "SHA", "Sandbox", "Scratch", "StyledStrings", "TOML", "Test", "TimerOutputs", "TreeArchival", "UserNSSandbox_jll", "gh_cli_jll"]
+path = "."
+uuid = "12aac903-9f7c-5d81-afc2-d9565ea332af"
+version = "2.0.0"
 
 [[deps.BinaryBuilderAuditor]]
 deps = ["BinaryBuilderProducts", "BinaryBuilderToolchains", "JLLGenerator", "ObjectFile", "Patchelf_jll", "StyledStrings"]
@@ -80,7 +86,7 @@ version = "4.16.0"
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.1.1+0"
+version = "1.3.0+1"
 
 [[deps.Dates]]
 deps = ["Printf"]
@@ -90,7 +96,7 @@ version = "1.11.0"
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
-version = "1.6.0"
+version = "1.7.0"
 
 [[deps.EnumX]]
 git-tree-sha1 = "bdb1942cd4c45e3c678fd11569d5cccd80976237"
@@ -159,6 +165,11 @@ git-tree-sha1 = "a007feb38b422fbdab534406aeca1b86823cb4d6"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 version = "1.7.0"
 
+[[deps.JuliaSyntaxHighlighting]]
+deps = ["StyledStrings"]
+uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
+version = "1.12.0"
+
 [[deps.KeywordArgumentExtraction]]
 deps = ["ExprTools", "InteractiveUtils"]
 path = "KeywordArgumentExtraction.jl"
@@ -187,24 +198,24 @@ uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
 version = "0.6.4"
 
 [[deps.LibCURL_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "8.6.0+0"
+version = "8.11.1+1"
 
 [[deps.LibGit2]]
-deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 version = "1.11.0"
 
 [[deps.LibGit2_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll"]
 uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
-version = "1.7.2+0"
+version = "1.9.0+0"
 
 [[deps.LibSSH2_jll]]
-deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+deps = ["Artifacts", "Libdl", "OpenSSL_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
-version = "1.11.0+1"
+version = "1.11.3+1"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -233,18 +244,13 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 version = "1.11.0"
 
 [[deps.Markdown]]
-deps = ["Base64"]
+deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 version = "1.11.0"
 
-[[deps.MbedTLS_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.6+0"
-
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2023.12.12"
+version = "2024.12.31"
 
 [[deps.MultiHashParsing]]
 deps = ["SHA"]
@@ -254,7 +260,7 @@ version = "0.1.0"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
-version = "1.2.0"
+version = "1.3.0"
 
 [[deps.ObjectFile]]
 deps = ["Reexport", "StructIO"]
@@ -263,10 +269,9 @@ uuid = "d8793406-e978-5875-9003-1fc021f44a92"
 version = "0.4.3"
 
 [[deps.OpenSSL_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "7493f61f55a6cce7325f197443aa80d32554ba10"
+deps = ["Artifacts", "Libdl"]
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.0.15+3"
+version = "3.0.16+0"
 
 [[deps.OrderedCollections]]
 git-tree-sha1 = "cc4054e898b852042d7b503313f7ad03de99c3dd"
@@ -284,7 +289,7 @@ version = "1.0.0"
 [[deps.PCRE2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
-version = "10.42.0+1"
+version = "10.44.0+1"
 
 [[deps.Patchelf_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
@@ -295,7 +300,7 @@ version = "0.18.0+0"
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.11.0"
+version = "1.12.0"
 
     [deps.Pkg.extensions]
     REPLExt = "REPL"
@@ -428,7 +433,7 @@ version = "2025.1.28+0"
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.13+1"
+version = "1.3.1+2"
 
 [[deps.Zstd_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -451,9 +456,9 @@ version = "0.3.101+0"
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-version = "1.59.0+0"
+version = "1.64.0+1"
 
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
-version = "17.4.0+2"
+version = "17.5.0+2"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ The `BinaryBuilder2.jl` package itself is the top-level project that includes al
 
 ## Current status
 
-Status as of April 2024 is that BinaryBuilder2 is still under heavy development and lacks full feature platform support.
-Current development target is for full feature parity with original `BinaryBuilder.jl` by JuliaCon 2024.
+Status as of Feburary 2025 is that BinaryBuilder2 is still under heavy development and lacks full feature platform support.
+Current development target is for full feature parity with original `BinaryBuilder.jl` by JuliaCon 2025.
 See `TODO.md` for the current worklist to be completed.


### PR DESCRIPTION
Here we move away from checking out an entire git registry for each universe, and instead creating a new registry to hold our builds, while overlaying it on top of the main registry.  This should improve startup/teardown costs significantly.