### PR TITLE
Universe rework

### DIFF
--- a/BinaryBuilderToolchains.jl/src/toolchains/HostToolsToolchain.jl
+++ b/BinaryBuilderToolchains.jl/src/toolchains/HostToolsToolchain.jl
@@ -5,7 +5,8 @@ using Pkg.Types: VersionSpec
 """
     HostToolsToolchain
 
-This toolchain contains a large number of useful host tools, such as 
+This toolchain contains a large number of useful host tools, such as make,
+ninja, perl, patchelf, tar, gzip, strace, libtree, git, and more!
 """
 struct HostToolsToolchain <: AbstractToolchain
     platform::Platform

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.11.3"
+julia_version = "1.11.4"
 manifest_format = "2.0"
-project_hash = "c2c0a9de51da846604f145b00627e6050ebdafbd"
+project_hash = "2dd6df3145bbd9d433a40b7b7bc9c8978dbc0fe8"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
@@ -23,7 +23,7 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 version = "1.11.0"
 
 [[deps.BinaryBuilderAuditor]]
-deps = ["BinaryBuilderProducts", "BinaryBuilderToolchains", "JLLGenerator", "ObjectFile", "Patchelf_jll", "StyledStrings"]
+deps = ["BinaryBuilderPlatformExtensions", "BinaryBuilderProducts", "BinaryBuilderSources", "BinaryBuilderToolchains", "JLLGenerator", "ObjectFile", "Pkg", "StyledStrings"]
 path = "BinaryBuilderAuditor.jl"
 uuid = "53524979-5234-6e31-4220-6120654b694c"
 version = "0.1.0"
@@ -285,12 +285,6 @@ version = "1.0.0"
 deps = ["Artifacts", "Libdl"]
 uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
 version = "10.42.0+1"
-
-[[deps.Patchelf_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "ad1cab3e8273c912f722f40779e20f3e29d58f1f"
-uuid = "f2cf89d6-2bfd-5c44-bd2c-068eea195c0c"
-version = "0.18.0+0"
 
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]

--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,7 @@ KeywordArgumentExtraction = "45533465-3150-2073-4772-41774b207255"
 LazyJLLWrappers = "21706172-204c-4d4f-5420-656854206f44"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LocalRegistry = "89398ba2-070a-4b16-a995-9893c55d93cf"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 MultiHashParsing = "73786568-6863-756d-6873-6168796e616d"
 ObjectFile = "d8793406-e978-5875-9003-1fc021f44a92"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
@@ -43,20 +44,23 @@ UserNSSandbox_jll = "b88861f7-1d72-59dd-91e7-a8cc876a4984"
 gh_cli_jll = "5d31d589-30fb-542f-b82d-10325e863e38"
 
 [compat]
+Accessors = "0.1.42"
 HistoricalStdlibVersions = "2"
 JLLPrefixes = "0.3.8"
+Logging = "1.11.0"
 OutputCollectors = "1"
 RegistryTools = "2.2.3"
-julia = "1.9"
-gh_cli_jll = "2.63.2"
 Sandbox = "2.1.0"
+gh_cli_jll = "2.63.2"
+julia = "1.9"
 
 [extras]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
+Patchelf_jll = "f2cf89d6-2bfd-5c44-bd2c-068eea195c0c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Accessors", "Test"]
+test = ["Accessors", "Test", "Patchelf_jll"]
 
 [workspace]
 projects = ["BinaryBuilderAuditor.jl", "BinaryBuilderGitUtils.jl", "BinaryBuilderPlatformExtensions.jl", "BinaryBuilderProducts.jl", "BinaryBuilderSources.jl", "BinaryBuilderToolchains.jl", "JLLGenerator.jl", "LazyJLLWrappers.jl", "MultiHashParsing.jl", "TreeArchival.jl", "KeywordArgumentExtraction.jl"]

--- a/test/BuildCacheTests.jl
+++ b/test/BuildCacheTests.jl
@@ -1,4 +1,4 @@
-using Test, BinaryBuilder2, SHA, MultiHashParsing, BinaryBuilderAuditor.Patchelf_jll
+using Test, BinaryBuilder2, SHA, MultiHashParsing, Patchelf_jll
 using BinaryBuilder2: load_cache, save_cache, prune!
 
 @testset "BuildCache" begin


### PR DESCRIPTION
This reworks our `Universe` to create a separate `BB2LocalRegistry`
where all JLL registrations are staged and clone `General` as a tarball
instead of as a git repository.  This significantly reduces the amount
of work needed to create a `Universe`, as well as simplifies universe
management when updating a persistent universe.