### PR TITLE
Make `rename_wrapper_prefixes` work for HostToolsToolchain

### DIFF
--- a/BinaryBuilderSources.jl/src/JLLSource.jl
+++ b/BinaryBuilderSources.jl/src/JLLSource.jl
@@ -157,9 +157,11 @@ function prepare(jlls::Vector{JLLSource};
     # two different versions of the same JLL to different prefixes.
     for (platform, platform_jlls_by_prefix) in jlls_by_platform_by_prefix
         for (prefix, jlls_slice) in platform_jlls_by_prefix
-            art_paths = collect_artifact_paths([jll.package for jll in jlls_slice]; platform, project_dir, pkg_depot=depot, verbose)
+            art_paths = collect_artifact_paths([jll.package for jll in jlls_slice]; platform, project_dir, pkg_depot=depot, verbose, from_current_manifest=true)
             for jll in jlls_slice
-                pkg = only([pkg for (pkg, _) in art_paths if pkg.uuid == jll.package.uuid])
+                pkgs = [pkg for (pkg, _) in art_paths if pkg.uuid == jll.package.uuid]
+                isempty(pkgs) && error("No artifacts found for JLL $(jll.package.name)!")
+                pkg = only(pkgs)
                 # Update `jll.package` with things from `pkg`
                 if pkg.version != Pkg.Types.VersionSpec()
                     jll.package.version = pkg.version
@@ -219,7 +221,7 @@ end
 # JLLSources are in a directory together.
 function content_hash(jll::JLLSource)
     checkprepared!("content_hash", jll)
-    
+
     entries = [(basename(apath), hex2bytes(basename(apath)), TreeArchival.mode_dir) for apath in jll.artifact_paths]
     return SHA1Hash(TreeArchival.tree_node_hash(SHA.SHA1_CTX, entries))
 end

--- a/src/build_api/BuildTargetSpec.jl
+++ b/src/build_api/BuildTargetSpec.jl
@@ -68,7 +68,7 @@ function rename_wrapper_prefixes(name::String, flags::Set{Symbol}, pw::Platforml
         wrapper_prefixes = String[]
         # env_prefixes control the naming of environment variables that point to our wrappers
         env_prefixes = String[]
-        
+
         # if `name` is "host", this makes a "host-x86_64-linux-gnu-gcc" wrapper.
         push!(wrapper_prefixes, string(name, "-\${triplet}-"))
         push!(wrapper_prefixes, "\${triplet}-")
@@ -89,6 +89,7 @@ function rename_wrapper_prefixes(name::String, flags::Set{Symbol}, pw::Platforml
     end
     return pw
 end
+rename_wrapper_prefixes(name::String, flags::Set{Symbol}, host::HostToolsToolchain) = host
 
 function alter_toolchain(target_prefix::String, pw::PlatformlessWrapper{CToolchain})
     # Alter this object to contain extra flags, prefixes, etc...


### PR DESCRIPTION
Seems to fix the following error:
```
ERROR: MethodError: no method matching rename_wrapper_prefixes(::String, ::Set{Symbol}, ::BinaryBuilderToolchains.HostToolsToolchain)
The function `rename_wrapper_prefixes` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  rename_wrapper_prefixes(::String, ::Set{Symbol}, ::BinaryBuilder2.PlatformlessWrapper{T}) where T
   @ BinaryBuilder2 ~/.julia/packages/BinaryBuilder2/xRv90/src/build_api/BuildTargetSpec.jl:64

Stacktrace:
  [1] (::BinaryBuilder2.var"#69#70"{String, BinaryBuilderPlatformExtensions.CrossPlatform, Set{Symbol}})(toolchain::BinaryBuilderToolchains.HostToolsToolchain)
    @ BinaryBuilder2 ~/.julia/packages/BinaryBuilder2/xRv90/src/build_api/BuildTargetSpec.jl:33
  [2] iterate
    @ ./generator.jl:48 [inlined]
  [3] collect_to!(dest::Vector{BinaryBuilderToolchains.CToolchain}, itr::Base.Generator{Vector{Union{BinaryBuilderToolchains.AbstractToolchain, BinaryBuilder2.PlatformlessWrapper{<:BinaryBuilderToolchains.AbstractToolchain}}}, BinaryBuilder2.var"#69#70"{String, BinaryBuilderPlatformExtensions.CrossPlatform, Set{Symbol}}}, offs::Int64, st::Int64)
    @ Base ./array.jl:854
  [4] collect_to_with_first!(dest::Vector{BinaryBuilderToolchains.CToolchain}, v1::BinaryBuilderToolchains.CToolchain, itr::Base.Generator{Vector{Union{BinaryBuilderToolchains.AbstractToolchain, BinaryBuilder2.PlatformlessWrapper{<:BinaryBuilderToolchains.AbstractToolchain}}}, BinaryBuilder2.var"#69#70"{String, BinaryBuilderPlatformExtensions.CrossPlatform, Set{Symbol}}}, st::Int64)
    @ Base ./array.jl:832
  [5] _collect(c::Vector{Union{BinaryBuilderToolchains.AbstractToolchain, BinaryBuilder2.PlatformlessWrapper{<:BinaryBuilderToolchains.AbstractToolchain}}}, itr::Base.Generator{Vector{Union{BinaryBuilderToolchains.AbstractToolchain, BinaryBuilder2.PlatformlessWrapper{<:BinaryBuilderToolchains.AbstractToolchain}}}, BinaryBuilder2.var"#69#70"{String, BinaryBuilderPlatformExtensions.CrossPlatform, Set{Symbol}}}, ::Base.EltypeUnknown, isz::Base.HasShape{1})
    @ Base ./array.jl:826
  [6] collect_similar
    @ ./array.jl:738 [inlined]
  [7] map
    @ ./abstractarray.jl:3374 [inlined]
  [8] BinaryBuilder2.BuildTargetSpec(name::String, platform::BinaryBuilderPlatformExtensions.CrossPlatform, toolchains::Vector{Any}, dependencies::Vector{Any}, flags::Set{Symbol})
    @ BinaryBuilder2 ~/.julia/packages/BinaryBuilder2/xRv90/src/build_api/BuildTargetSpec.jl:28
```

I don't have a full enough view of the package to say that this is the correct fix though.