### PR TITLE
Fix BuildCache data loss when multiple metas share the same cache_dir

### DIFF
--- a/src/BuildCache.jl
+++ b/src/BuildCache.jl
@@ -244,6 +244,64 @@ function import_archives(bc::BuildCache, dir::String)
 end
 
 
+function load_build_entries!(build_entries::Dict{SHA1Hash,BuildCacheBuildEntry}, cache_dir::String)
+    safe_open(joinpath(cache_dir, "build_entries.db"); read=true) do io
+        for line in readlines(io)
+            parts = split(line, " ")
+            length(parts) == 2 || continue
+            build_hash_str, log_artifact_hash_str = parts
+            env_path = joinpath(cache_dir, "envs", "$(build_hash_str).env")
+            if !isfile(env_path)
+                continue
+            end
+            try
+                build_hash = SHA1Hash(build_hash_str)
+                log_artifact_hash = SHA1Hash(log_artifact_hash_str)
+                env = parse_env_block(String(read(env_path)))
+                build_entries[build_hash] = BuildCacheBuildEntry(log_artifact_hash, env)
+            catch
+                @debug("skip: build entry malformed", build_hash=build_hash_str)
+                continue
+            end
+        end
+    end
+end
+
+function load_extract_entries!(extract_entries::Dict{SHA1Hash,BuildCacheExtractEntry}, cache_dir::String)
+    safe_open(joinpath(cache_dir, "extract_entries.db"); read=true) do io
+        for line in readlines(io)
+            parts = split(line, " ")
+            length(parts) == 3 || continue
+            extract_hash_str, artifact_hash_str, log_artifact_hash_str = parts
+            jlp_path = joinpath(cache_dir, "jll_lib_products", "$(extract_hash_str).jlp")
+            if !isfile(jlp_path)
+                @debug("skip: jlp nonexistent", extract_hash=extract_hash_str)
+                continue
+            end
+            local jll_lib_products
+            try
+                jll_lib_products = TOML.parsefile(jlp_path)["jll_lib_products"]
+            catch
+                @debug("skip: jlp malformed", extract_hash=extract_hash_str)
+                continue
+            end
+            try
+                extract_hash = SHA1Hash(extract_hash_str)
+                artifact_hash = SHA1Hash(artifact_hash_str)
+                log_artifact_hash = SHA1Hash(log_artifact_hash_str)
+                extract_entries[extract_hash] = BuildCacheExtractEntry(
+                    artifact_hash,
+                    log_artifact_hash,
+                    parse_toml_dict.(JLLLibraryProduct, jll_lib_products),
+                )
+            catch
+                @debug("skip: extract entry malformed", extract_hash=extract_hash_str)
+                continue
+            end
+        end
+    end
+end
+
 function save_cache(bc::BuildCache)
     # Only try to save if the cache_dir still exists.  For temporary universes, this will not be the case.
     if !isdir(bc.cache_dir)
@@ -255,10 +313,21 @@ function save_cache(bc::BuildCache)
         println(io, bc.artifacts_dir)
     end
 
+    # Reload the on-disk state and merge with our in-memory entries before writing.
+    # This prevents data loss when multiple BuildCache objects share the same cache_dir
+    # (e.g. multiple BuildMeta objects in one process) and save sequentially at exit.
+    merged_build_entries = Dict{SHA1Hash,BuildCacheBuildEntry}()
+    load_build_entries!(merged_build_entries, bc.cache_dir)
+    merge!(merged_build_entries, bc.build_entries)
+
+    merged_extract_entries = Dict{SHA1Hash,BuildCacheExtractEntry}()
+    load_extract_entries!(merged_extract_entries, bc.cache_dir)
+    merge!(merged_extract_entries, bc.extract_entries)
+
     # Serialize out build entries
     mkpath(joinpath(bc.cache_dir, "envs"))
     open(joinpath(bc.cache_dir, "build_entries.db"); write=true) do io
-        for (build_hash, b) in bc.build_entries
+        for (build_hash, b) in merged_build_entries
             println(io, "$(bytes2hex(build_hash)) $(bytes2hex(b.log_artifact))")
 
             # Environment mappings get saved to a separate file, to ease serialization
@@ -275,7 +344,7 @@ function save_cache(bc::BuildCache)
     # Serialize out extraction output cache
     mkpath(joinpath(bc.cache_dir, "jll_lib_products"))
     open(joinpath(bc.cache_dir, "extract_entries.db"); write=true) do io
-        for (extract_hash, e) in bc.extract_entries
+        for (extract_hash, e) in merged_extract_entries
             println(io, "$(bytes2hex(extract_hash)) $(bytes2hex(e.artifact)) $(bytes2hex(e.log_artifact))")
 
             # JLL library information gets saved to a separate file, to ease serialization
@@ -303,74 +372,11 @@ end
 function load_cache(cache_dir::String = default_buildcache_dir())
     artifacts_dir = Ref(joinpath(first(Base.DEPOT_PATH), "artifacts"))
 
-    # Iterate over `build_entries.db`, try to reconstitute `BuildCacheBuildEntry` objects
     build_entries = Dict{SHA1Hash,BuildCacheBuildEntry}()
-    safe_open(joinpath(cache_dir, "build_entries.db"); read=true) do io
-        for line in readlines(io)
-            # Try to read this line's hashes
-            build_hash, log_artifact_hash = split(line, " ")
+    load_build_entries!(build_entries, cache_dir)
 
-            # Immediately look to see if we have an environment mapping
-            env_path = joinpath(cache_dir, "envs", "$(build_hash).env")
-            if !isfile(env_path)
-                continue
-            end
-
-            # Parse them as SHA1Hash'es
-            try
-                build_hash = SHA1Hash(build_hash)
-                log_artifact_hash = SHA1Hash(log_artifact_hash)
-            catch
-                continue
-            end
-
-            env = parse_env_block(String(read(env_path)))
-            build_entries[build_hash] = BuildCacheBuildEntry(
-                log_artifact_hash,
-                env,
-            )
-        end
-    end
-
-    # Iterate over `extract_entries.db`, try to reconstitute `BuildCacheExtractEntry` objects
     extract_entries = Dict{SHA1Hash,BuildCacheExtractEntry}()
-    safe_open(joinpath(cache_dir, "extract_entries.db"); read=true) do io
-        for line in readlines(io)
-            # Try to read this line's hashes
-            extract_hash, artifact_hash, log_artifact_hash = split(line, " ")
-            
-            # Immediately look to see if we have a jll_lib_products mapping
-            jlp_path = joinpath(cache_dir, "jll_lib_products", "$(extract_hash).jlp")
-            if !isfile(jlp_path)
-                @debug("skip: jlp nonexistent", extract_hash)
-                continue
-            end
-
-            local jll_lib_products
-            try
-                jll_lib_products = TOML.parsefile(jlp_path)["jll_lib_products"]
-            catch
-                @debug("skip: jlp malformed", extract_hash)
-                continue
-            end
-
-            # Parse them as SHA1Hash'es, skipping if anything isn't working
-            try
-                extract_hash = SHA1Hash(extract_hash)
-                artifact_hash = SHA1Hash(artifact_hash)
-                log_artifact_hash = SHA1Hash(log_artifact_hash)
-            catch
-                @debug("skip: hashes malformed", extract_hash)
-                continue
-            end
-
-            extract_entries[extract_hash] = BuildCacheExtractEntry(
-                artifact_hash,
-                log_artifact_hash,
-                parse_toml_dict.(JLLLibraryProduct, jll_lib_products),
-            )
-        end
-    end
+    load_extract_entries!(extract_entries, cache_dir)
 
     safe_open(joinpath(cache_dir, "artifacts_dir"); read=true) do io
         new_artifacts_dir = first(readlines(io))

--- a/test/BuildCacheTests.jl
+++ b/test/BuildCacheTests.jl
@@ -1,5 +1,6 @@
 using Test, Pkg, BinaryBuilder2, SHA, MultiHashParsing, Patchelf_jll
 using BinaryBuilder2: load_cache, save_cache, prune!, export_archive, import_archives
+using BinaryBuilder2: load_build_entries!, load_extract_entries!
 using BinaryBuilder2: BuildCacheBuildEntry, BuildCacheExtractEntry, Universe
 using JLLGenerator
 
@@ -107,5 +108,130 @@ using JLLGenerator
 
         import_archives(bc3, archive_dir)
         probe_buildcache(bc3)
+    end
+end
+
+@testset "load_build_entries!" begin
+    using BinaryBuilder2: serialize_env_block
+
+    mktempdir() do cache_dir
+        mkpath(joinpath(cache_dir, "envs"))
+
+        h1 = SHA1Hash(sha1("build1"))
+        h2 = SHA1Hash(sha1("build2"))
+        log1 = SHA1Hash(sha1("log1"))
+        log2 = SHA1Hash(sha1("log2"))
+        env1 = Dict("A" => "1", "B" => "2")
+        env2 = Dict("X" => "y")
+
+        # Write env files
+        write(joinpath(cache_dir, "envs", "$(bytes2hex(h1)).env"), serialize_env_block(env1))
+        write(joinpath(cache_dir, "envs", "$(bytes2hex(h2)).env"), serialize_env_block(env2))
+
+        # Write a valid build_entries.db
+        db = joinpath(cache_dir, "build_entries.db")
+        write(db, "$(bytes2hex(h1)) $(bytes2hex(log1))\n$(bytes2hex(h2)) $(bytes2hex(log2))\n")
+
+        entries = Dict{SHA1Hash,BuildCacheBuildEntry}()
+        load_build_entries!(entries, cache_dir)
+        @test length(entries) == 2
+        @test entries[h1] == BuildCacheBuildEntry(log1, env1)
+        @test entries[h2] == BuildCacheBuildEntry(log2, env2)
+
+        # Missing .env file → entry skipped
+        rm(joinpath(cache_dir, "envs", "$(bytes2hex(h2)).env"))
+        entries2 = Dict{SHA1Hash,BuildCacheBuildEntry}()
+        load_build_entries!(entries2, cache_dir)
+        @test haskey(entries2, h1)
+        @test !haskey(entries2, h2)
+
+        # Malformed hash line → entry skipped
+        write(db, "$(bytes2hex(h1)) $(bytes2hex(log1))\nnotahash notahash\n")
+        write(joinpath(cache_dir, "envs", "$(bytes2hex(h2)).env"), serialize_env_block(env2))
+        entries3 = Dict{SHA1Hash,BuildCacheBuildEntry}()
+        load_build_entries!(entries3, cache_dir)
+        @test length(entries3) == 1
+        @test haskey(entries3, h1)
+
+        # Missing db file → empty result, no error
+        rm(db)
+        entries4 = Dict{SHA1Hash,BuildCacheBuildEntry}()
+        load_build_entries!(entries4, cache_dir)
+        @test isempty(entries4)
+
+        # Pre-existing entries in the dict are preserved (merge semantics)
+        write(db, "$(bytes2hex(h1)) $(bytes2hex(log1))\n")
+        existing_entry = BuildCacheBuildEntry(SHA1Hash(sha1("other")), Dict("Z" => "z"))
+        entries5 = Dict{SHA1Hash,BuildCacheBuildEntry}(h2 => existing_entry)
+        load_build_entries!(entries5, cache_dir)
+        @test haskey(entries5, h1)
+        @test entries5[h2] === existing_entry
+    end
+end
+
+@testset "load_extract_entries!" begin
+    using BinaryBuilder2: export_jll_lib_products
+
+    mktempdir() do cache_dir
+        mkpath(joinpath(cache_dir, "jll_lib_products"))
+
+        h1 = SHA1Hash(sha1("extract1"))
+        h2 = SHA1Hash(sha1("extract2"))
+        art1 = SHA1Hash(sha1("artifact1"))
+        art2 = SHA1Hash(sha1("artifact2"))
+        log1 = SHA1Hash(sha1("extlog1"))
+        log2 = SHA1Hash(sha1("extlog2"))
+        jlp1 = [JLLLibraryProduct(:libfoo, "lib/libfoo.so", [], flags=[:RTLD_LAZY])]
+        jlp2 = JLLLibraryProduct[]
+
+        # Write .jlp files
+        export_jll_lib_products(jlp1, joinpath(cache_dir, "jll_lib_products", "$(bytes2hex(h1)).jlp"))
+        export_jll_lib_products(jlp2, joinpath(cache_dir, "jll_lib_products", "$(bytes2hex(h2)).jlp"))
+
+        # Write a valid extract_entries.db
+        db = joinpath(cache_dir, "extract_entries.db")
+        write(db, "$(bytes2hex(h1)) $(bytes2hex(art1)) $(bytes2hex(log1))\n$(bytes2hex(h2)) $(bytes2hex(art2)) $(bytes2hex(log2))\n")
+
+        entries = Dict{SHA1Hash,BuildCacheExtractEntry}()
+        load_extract_entries!(entries, cache_dir)
+        @test length(entries) == 2
+        @test entries[h1] == BuildCacheExtractEntry(art1, log1, jlp1)
+        @test entries[h2] == BuildCacheExtractEntry(art2, log2, jlp2)
+
+        # Missing .jlp file → entry skipped
+        rm(joinpath(cache_dir, "jll_lib_products", "$(bytes2hex(h2)).jlp"))
+        entries2 = Dict{SHA1Hash,BuildCacheExtractEntry}()
+        load_extract_entries!(entries2, cache_dir)
+        @test haskey(entries2, h1)
+        @test !haskey(entries2, h2)
+
+        # Malformed TOML in .jlp → entry skipped
+        write(joinpath(cache_dir, "jll_lib_products", "$(bytes2hex(h2)).jlp"), "not valid toml [[[")
+        entries3 = Dict{SHA1Hash,BuildCacheExtractEntry}()
+        load_extract_entries!(entries3, cache_dir)
+        @test haskey(entries3, h1)
+        @test !haskey(entries3, h2)
+
+        # Malformed hash line → entry skipped
+        write(db, "$(bytes2hex(h1)) $(bytes2hex(art1)) $(bytes2hex(log1))\nnotahash notahash notahash\n")
+        export_jll_lib_products(jlp2, joinpath(cache_dir, "jll_lib_products", "$(bytes2hex(h2)).jlp"))
+        entries4 = Dict{SHA1Hash,BuildCacheExtractEntry}()
+        load_extract_entries!(entries4, cache_dir)
+        @test length(entries4) == 1
+        @test haskey(entries4, h1)
+
+        # Missing db file → empty result, no error
+        rm(db)
+        entries5 = Dict{SHA1Hash,BuildCacheExtractEntry}()
+        load_extract_entries!(entries5, cache_dir)
+        @test isempty(entries5)
+
+        # Pre-existing entries in the dict are preserved (merge semantics)
+        write(db, "$(bytes2hex(h1)) $(bytes2hex(art1)) $(bytes2hex(log1))\n")
+        existing_entry = BuildCacheExtractEntry(SHA1Hash(sha1("other")), SHA1Hash(sha1("otherlog")), jlp2)
+        entries6 = Dict{SHA1Hash,BuildCacheExtractEntry}(h2 => existing_entry)
+        load_extract_entries!(entries6, cache_dir)
+        @test haskey(entries6, h1)
+        @test entries6[h2] === existing_entry
     end
 end


### PR DESCRIPTION
When multiple `BuildMeta` objects exist in one process (e.g. during bootstrap), each holds a separate `BuildCache` loaded from the same directory. At exit, each calls `save_cache` in turn, and the later writes would overwrite the `.db` files — dropping entries written by earlier saves.

Fix: extract the `.db` parsing into `load_build_entries!` and `load_extract_entries!` helpers, then have `save_cache` reload the current on-disk state and merge it with in-memory entries before writing. In-memory entries take priority (they are the result of this process's builds). `load_cache` is refactored to delegate to the same helpers.  Unit tests added for both helpers covering happy path, missing/malformed sidecar files, missing db, and merge semantics.

Also guard the `split(line, " ")` destructuring in both helpers with a field-count check (wrong-token-count lines are silently skipped), and add `@debug` messages to the bare `catch` blocks so skipped entries are observable under `JULIA_DEBUG`.

Fixes #28