### PR TITLE
Implement per-build ccache statistics

### DIFF
--- a/src/build_api/BuildConfig.jl
+++ b/src/build_api/BuildConfig.jl
@@ -174,6 +174,7 @@ struct BuildConfig
 
             # ccache
             "CCACHE_DIR" => "/var/cache/ccache",
+            "CCACHE_STATSLOG" => "$(metadir_prefix())/ccache-statslog",
         ))
 
         return new(
@@ -548,6 +549,12 @@ function build!(config::BuildConfig;
         env = Dict{String,String}()
     end
 
+    # Try to capture the ccache statslog written to the metadir
+    ccache_log_artifact_hash = nothing
+    if run_status != :errored
+        ccache_log_artifact_hash = store_ccache_log_artifact(meta.universe, read_metadir_ccache_statslog(exe, config, mounts))
+    end
+
     result = BuildResult(
         config,
         run_status,
@@ -556,6 +563,7 @@ function build!(config::BuildConfig;
         mounts,
         log_artifact_hash,
         env,
+        ccache_log_artifact_hash,
     )
     meta.builds[config] = result
 

--- a/src/build_api/BuildResult.jl
+++ b/src/build_api/BuildResult.jl
@@ -1,5 +1,6 @@
+using Ccache_jll
 export BuildResult
-export build_log
+export build_log, ccache_stats
 
 """
     BuildResult
@@ -30,13 +31,17 @@ mutable struct BuildResult
     # The final environment of this build result.
     env::Dict{String,String}
 
+    # ccache per-build statistics log artifact (nothing if ccache was not invoked or build was cached)
+    ccache_log_artifact::Union{Nothing,SHA1Hash}
+
     function BuildResult(config::BuildConfig,
                          status::Symbol,
                          exception::Union{Nothing,Exception},
                          exe::Union{Nothing,SandboxExecutor},
                          mounts::Dict{String,MountInfo},
                          log_artifact::Union{Nothing,SHA1Hash},
-                         env::Dict{String,String})
+                         env::Dict{String,String},
+                         ccache_log_artifact::Union{Nothing,SHA1Hash} = nothing)
         obj = new(
             config,
             status,
@@ -45,6 +50,7 @@ mutable struct BuildResult
             mounts,
             log_artifact,
             env,
+            ccache_log_artifact,
         )
         # Make sure that this is cleaned up _before_ we're in a finalizer.
         push!(get_exit_hooks(), obj)
@@ -140,6 +146,18 @@ function Base.read(exe::SandboxExecutor, config::BuildConfig, mounts::Dict{Strin
     return take!(stdout)
 end
 
+function store_ccache_log_artifact(universe, data::Union{AbstractVector{UInt8},Nothing})
+    (data === nothing || isempty(data)) && return nothing
+    hash = in_universe(universe) do _
+        Pkg.Artifacts.create_artifact() do artifact_dir
+            open(joinpath(artifact_dir, "ccache-statslog"); write=true) do io
+                write(io, data)
+            end
+        end
+    end
+    return SHA1Hash(hash)
+end
+
 function build_log(br::BuildResult)
     if br.log_artifact === nothing
         throw(ArgumentError("Skipped BuildResult's don't have a build log!"))
@@ -148,8 +166,38 @@ function build_log(br::BuildResult)
     return String(read(joinpath(build_log_path, "$(br.config.src_name)-build.log")))
 end
 
+"""
+    ccache_stats(result::BuildResult; io::IO = stdout)
+
+Display per-build ccache statistics for the given `BuildResult`.  Statistics are
+collected via `CCACHE_STATSLOG` during the build and shown using `ccache --show-log-stats`.
+Returns `nothing` if ccache was not invoked during the build or if the build was cached/skipped.
+"""
+function ccache_stats(result::BuildResult; io::IO = stdout)
+    if result.ccache_log_artifact === nothing
+        @warn("No ccache statslog available for this BuildResult (build may have been cached/skipped, or ccache was not invoked)")
+        return nothing
+    end
+    ccache_log_path = artifact_path(result.config.meta.universe, result.ccache_log_artifact)
+    statslog_file = joinpath(ccache_log_path, "ccache-statslog")
+    run(pipeline(
+        addenv(`$(ccache()) --show-log-stats`, "CCACHE_STATSLOG" => statslog_file, "CCACHE_DIR" => ccache_cache("ccache")),
+        stdout = io,
+    ))
+    return nothing
+end
+
 function parse_metadir_env(exe::SandboxExecutor, config::BuildConfig, mounts::Dict{String,MountInfo})
     return parse_env_block(String(read(exe, config, mounts, "$(metadir_prefix())/env")))
+end
+
+function read_metadir_ccache_statslog(exe::SandboxExecutor, config::BuildConfig, mounts::Dict{String,MountInfo})
+    try
+        return read(exe, config, mounts, "$(metadir_prefix())/ccache-statslog")
+    catch e
+        e isa ArgumentError || rethrow()
+        return nothing
+    end
 end
 
 function parse_env_block(env_string::AbstractString)

--- a/test/BuildAPITests.jl
+++ b/test/BuildAPITests.jl
@@ -7,7 +7,25 @@ end
 
 @testset "BuildAPI" begin
 
-using BinaryBuilder2: next_jll_version
+using BinaryBuilder2: next_jll_version, store_ccache_log_artifact, read_metadir_ccache_statslog, artifact_path
+@testset "store_ccache_log_artifact" begin
+    mktempdir() do depot_path
+        uni = Universe(; depot_path, persistent=false)
+
+        # nothing and empty data both return nothing
+        @test store_ccache_log_artifact(uni, nothing) === nothing
+        @test store_ccache_log_artifact(uni, UInt8[]) === nothing
+
+        # non-empty data creates an artifact and returns its hash
+        data = b"Cachefile hits:    42\nCache misses:      7\n"
+        hash = store_ccache_log_artifact(uni, data)
+        @test hash isa SHA1Hash
+        statslog_file = joinpath(artifact_path(uni, hash), "ccache-statslog")
+        @test isfile(statslog_file)
+        @test read(statslog_file) == data
+    end
+end
+
 @testset "next_jll_version" begin
     versions = [
         v"1.0.0",
@@ -41,6 +59,31 @@ end
     @test failing_build_result.status == :failed
     @test failing_build_result.env["env_val"] == "pre"
     @test occursin("Previous command 'false' exited with code 1", build_log(failing_build_result))
+
+    # read_metadir_ccache_statslog returns nothing when ccache was never invoked
+    @test failing_build_result.ccache_log_artifact === nothing
+
+    # ccache_stats warns and returns nothing when no statslog is available
+    @test_logs (:warn, r"No ccache statslog") begin
+        @test ccache_stats(failing_build_result) === nothing
+    end
+
+    # ccache_stats runs ccache --show-log-stats against a real (dummy) statslog artifact
+    dummy_statslog = b"1234567890.000000 cache_miss\n1234567890.000001 cache_hit(preprocessed)\n"
+    dummy_ccache_artifact = store_ccache_log_artifact(meta.universe, dummy_statslog)
+    dummy_result = BuildResult(
+        bad_build_config,
+        :success,
+        nothing,
+        nothing,
+        Dict{String,MountInfo}(),
+        failing_build_result.log_artifact,
+        Dict{String,String}(),
+        dummy_ccache_artifact,
+    )
+    buf = IOBuffer()
+    @test ccache_stats(dummy_result; io=buf) === nothing
+    @test !isempty(String(take!(buf)))
 end
 
 include("BuildAPITests/LowLevelBuildTests.jl")

--- a/test/BuildAPITests.jl
+++ b/test/BuildAPITests.jl
@@ -1,4 +1,4 @@
-using Test, BinaryBuilder2, Random
+using Test, BinaryBuilder2, Random, Sandbox
 
 if !isdefined(@__MODULE__, :TestingUtils)
     include(joinpath(pkgdir(BinaryBuilder2), "test", "TestingUtils.jl"))
@@ -69,7 +69,7 @@ end
     end
 
     # ccache_stats runs ccache --show-log-stats against a real (dummy) statslog artifact
-    dummy_statslog = b"1234567890.000000 cache_miss\n1234567890.000001 cache_hit(preprocessed)\n"
+    dummy_statslog = b"cache_miss\ncache_hit(preprocessed)\n"
     dummy_ccache_artifact = store_ccache_log_artifact(meta.universe, dummy_statslog)
     dummy_result = BuildResult(
         bad_build_config,


### PR DESCRIPTION
Set CCACHE_STATSLOG in the build environment so ccache writes per-invocation stats to the metadir. After each build, read_metadir_ccache_statslog() reads that file (returning nothing if absent), and store_ccache_log_artifact() stores the data as an artifact on the BuildResult. ccache_stats(result; io=stdout) displays the stats on demand via ccache --show-log-stats.

Closes #38