### PR TITLE
Add documentation build workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -31,4 +31,3 @@ jobs:
       - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,34 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      statuses: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: "1.12"
+      - uses: julia-actions/cache@v2
+        with:
+          cache-registries: "true"
+      - name: Install dependencies
+        shell: julia --color=yes --project=docs/ {0}
+        run: |
+          using Pkg
+          Pkg.Registry.update()
+          Pkg.develop(PackageSpec(path=pwd()))
+          Pkg.instantiate()
+      - uses: julia-actions/julia-docdeploy@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # BinaryBuilder2
 
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaPackaging.github.io/BinaryBuilder2.jl/stable/)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaPackaging.github.io/BinaryBuilder2.jl/dev/)
+
 `BinaryBuilder2` represents the next evolution of [`BinaryBuilder.jl`](https://github.com/JuliaPackaging/BinaryBuilder.jl).
 It is a greenfield rewrite of the entire stack, from the isolation layer now using [`Sandbox.jl`](https://github.com/staticfloat/Sandbox.jl), git utilities, tree archival, binary object analysis and more being provided in separate modular packages.
 The `BinaryBuilder2.jl` package itself is the top-level project that includes all these sub-packages, but each sub-package itself is useful and independently tested.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,8 +9,10 @@ DocMeta.setdocmeta!(
 )
 
 makedocs(
-    sitename = "BinaryBuilder2",
-    format = Documenter.HTML(),
+    sitename = "BinaryBuilder2.jl",
+    format = Documenter.HTML(
+        repolink = "https://github.com/JuliaPackaging/BinaryBuilder2.jl",
+    ),
     modules = [BinaryBuilder2],
     pages = [
         "Overview" => "index.md",
@@ -30,9 +32,7 @@ makedocs(
     checkdocs = :warnonly,
 )
 
-# Documenter can also automatically deploy documentation to gh-pages.
-# See "Hosting Documentation" and deploydocs() in the Documenter manual
-# for more information.
-#=deploydocs(
-    repo = "<repository url>"
-)=#
+deploydocs(
+    repo = "github.com/JuliaPackaging/BinaryBuilder2.jl",
+    devbranch = "main",
+)


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds and deploys docs to GitHub Pages on pushes to main and tags, using julia-docdeploy. Adds stable and dev documentation badges to the README.

This may need to set up a DOCUMENTER_KEY in secrets before merging, as well as defining the site branch in https://github.com/JuliaPackaging/BinaryBuilder2.jl/settings/pages