### PR TITLE
Extend `JLL.toml` format for static libraries (and more)

### DIFF
--- a/JLLGenerator.jl/src/JLLGenerator.jl
+++ b/JLLGenerator.jl/src/JLLGenerator.jl
@@ -6,8 +6,8 @@ import Base: UUID
 
 export JLLInfo, JLLBuildInfo, JLLSourceRecord, JLLArtifactSource, JLLLibraryDep,
        AbstractJLLProduct, JLLExecutableProduct, JLLFileProduct, JLLLibraryProduct,
-       JLLPackageDependency, JLLArtifactBinding, AbstractProducts, JLLBuildLicense,
-       generate_jll, generate_toml_dict, parse_toml_dict
+       JLLPackageDependency, JLLArtifactBinding, JuliaBundledPath, AbstractProducts,
+       JLLBuildLicense, generate_jll, generate_toml_dict, parse_toml_dict
 
 include("RTLD_flags.jl")
 include("PkgCompatHacks.jl")
@@ -123,6 +123,7 @@ function generate_toml_dict(lp::JLLLibraryProduct)
     d = Dict(
         "type" => "library",
         "name" => string(lp.varname),
+        "linkage" => "dynamic",
         "path" => lp.path,
         "deps" => generate_toml_dict.(lp.deps),
         "soname" => lp.soname,
@@ -134,6 +135,10 @@ function generate_toml_dict(lp::JLLLibraryProduct)
     return d
 end
 function parse_toml_dict(::Type{JLLLibraryProduct}, d)
+    linkage = get(d, "linkage", "dynamic")
+    if linkage != "dynamic"
+        throw(ArgumentError("Invalid linkage '$(linkage)' for library '$(d["name"])'; expected \"dynamic\""))
+    end
     on_load_callback = nothing
     if haskey(d, "on_load_callback")
         on_load_callback = Symbol(d["on_load_callback"])
@@ -301,6 +306,53 @@ end
 
 
 """
+    JuliaBundledPath
+
+The products of a build that ships inside the Julia distribution rather than in an
+artifact, as Julia's own pseudo-JLLs do. The `bundled_path` can be "private_shlibdir",
+"private_bindir", or "private_libdir".
+"""
+@struct_hash_equal struct JuliaBundledPath
+    bundled_path::String
+
+    function JuliaBundledPath(bundled_path)
+        return new(String(bundled_path))
+    end
+end
+
+function JuliaBundledPath(; bundled_path)
+    return JuliaBundledPath(bundled_path)
+end
+
+function generate_toml_dict(info::JuliaBundledPath)
+    return Dict(
+        "bundled_path" => info.bundled_path,
+    )
+end
+
+function parse_toml_dict(::Type{JuliaBundledPath}, d::Dict)
+    return JuliaBundledPath(;
+        bundled_path = d["bundled_path"],
+    )
+end
+
+function parse_artifact_dict(d::Dict)
+    binds_artifact = haskey(d, "treehash") || haskey(d, "download_sources")
+    is_bundled = haskey(d, "bundled_path")
+    if binds_artifact && is_bundled
+        throw(ArgumentError("This `artifact` table binds an artifact and also names a bundled path; it must do one or the other!"))
+    elseif binds_artifact
+        return parse_toml_dict(JLLArtifactBinding, d)
+    elseif is_bundled
+        return parse_toml_dict(JuliaBundledPath, d)
+    else
+        keylist = join(repr.(sort(collect(string.(keys(d))))), ", ")
+        throw(ArgumentError("Unrecognized `artifact` table with keys [$(keylist)]; expected a `treehash` or a `bundled_path`!"))
+    end
+end
+
+
+"""
     JLLBuildLicense
 
 Describes the license a JLL build is released under.  Contains a `filename`, and the
@@ -371,9 +423,12 @@ easier for non-BinaryBuilder2 users to make use of this package if needed.
     # The platform this is built for
     platform::AbstractPlatform
 
-    # The name and artifact bindings for this artifact
+    # The name of this build
     name::String
-    artifact::JLLArtifactBinding
+
+    # The location where the products are to be found: either bound
+    # to an artifact, or bundled with Julia (stdlib pseudo-JLLs).
+    artifact::Union{JLLArtifactBinding,JuliaBundledPath}
     auxilliary_artifacts::Dict{String,JLLArtifactBinding}
 
     # List of products in cut-down JLL format
@@ -398,8 +453,8 @@ easier for non-BinaryBuilder2 users to make use of this package if needed.
     # __init__ snippet definition as a string, or `nothing` if not needed.
     init_def::Union{Nothing,String}
 
-    function JLLBuildInfo(src_version, platform, name, artifact, auxilliary_artifacts, products,
-                          deps, sources, licenses, lazy, callback_defs, init_def)
+    function JLLBuildInfo(src_version, platform, name, artifact, auxilliary_artifacts,
+                          products, deps, sources, licenses, lazy, callback_defs, init_def)
         # Quick verification of dependency structure, to ensure we're not incoherent.
         for p in products
             if isa(p, JLLLibraryProduct)
@@ -447,22 +502,23 @@ easier for non-BinaryBuilder2 users to make use of this package if needed.
     end
 end
 
-function JLLBuildInfo(;src_version, platform, name, artifact, products, licenses,
+function JLLBuildInfo(;src_version, platform, name,
+                          artifact = JuliaBundledPath("private_shlibdir"), products, licenses,
                           deps = [], sources = [], lazy = false, callback_defs = Dict(),
                           init_def = nothing, auxilliary_artifacts = Dict())
-    return JLLBuildInfo(src_version, platform, name, artifact, auxilliary_artifacts, products,
-                           deps, sources, licenses, lazy, callback_defs, init_def)
+    return JLLBuildInfo(src_version, platform, name, artifact, auxilliary_artifacts,
+                           products, deps, sources, licenses, lazy, callback_defs, init_def)
 end
 
 function generate_toml_dict(info::JLLBuildInfo)
     d = Dict(
+        "artifact" => generate_toml_dict(info.artifact),
         "src_version" => info.src_version,
         "deps" => generate_toml_dict.(info.deps),
         "sources" => generate_toml_dict.(info.sources),
         "licenses" => generate_toml_dict.(info.licenses),
         "platform" => triplet(info.platform),
         "name" => string(info.name),
-        "artifact" => generate_toml_dict(info.artifact),
         "auxilliary_artifacts" => Dict(string(name) => generate_toml_dict(art) for (name, art) in info.auxilliary_artifacts),
         "lazy" => string(info.lazy),
         "callback_defs" => Dict(string(k) => v for (k, v) in info.callback_defs),
@@ -482,7 +538,7 @@ function parse_toml_dict(::Type{JLLBuildInfo}, d::Dict)
         licenses = parse_toml_dict.(JLLBuildLicense, d["licenses"]),
         platform = parse(AbstractPlatform, d["platform"]),
         name = d["name"],
-        artifact = parse_toml_dict(JLLArtifactBinding, d["artifact"]),
+        artifact = parse_artifact_dict(d["artifact"]),
         auxilliary_artifacts = Dict(name => parse_toml_dict(JLLArtifactBinding, art) for (name, art) in d["auxilliary_artifacts"]),
         lazy = parse(Bool, d["lazy"]),
         callback_defs = Dict{Symbol,String}(Symbol(k) => string(v) for (k,v) in d["callback_defs"]),
@@ -514,7 +570,7 @@ end
     JLLInfo
 
 A structure representing a JLL that is to be generated.  All relevant information on the
-JLL is stored within, including sources 
+JLL is stored within, including sources
 """
 @struct_hash_equal struct JLLInfo
     # Name of the JLL, e.g. `libfoo_jll`
@@ -580,6 +636,7 @@ UUID(info::JLLInfo) = jll_specific_uuid5(uuid_package, "$(info.name)_jll_jll")
 
 function generate_toml_dict(info::JLLInfo)
     return Dict(
+        "format_version" => "1.0",
         "name" => info.name,
         "version" => string(info.version),
         "builds" => generate_toml_dict.(info.builds),
@@ -589,6 +646,7 @@ function generate_toml_dict(info::JLLInfo)
 end
 
 function parse_toml_dict(::Type{JLLInfo}, d::Dict)
+    check_format_version(d)
     return JLLInfo(;
         name = d["name"],
         version = VersionNumber(d["version"]),
@@ -597,6 +655,21 @@ function parse_toml_dict(::Type{JLLInfo}, d::Dict)
         julia_compat = d["julia_compat"],
     )
 end
+
+function check_format_version(jll)
+    if !haskey(jll, "format_version")
+        return v"1.0.0"
+    end
+    format = tryparse(VersionNumber, string(jll["format_version"]))
+    if format === nothing
+        throw(ArgumentError("invalid `format_version`"))
+    end
+    if format.major != 1
+        throw(ArgumentError("unsupported `format_version` v$(format.major); expected v1"))
+    end
+    return format
+end
+
 parse_toml_dict(d::Dict) = parse_toml_dict(JLLInfo, d)
 
 function bind_jll_artifact!(artifacts_toml_path::String, name::String, platform::AbstractPlatform,
@@ -658,6 +731,10 @@ function generate_jll(out_dir::String, info::JLLInfo; clear::Bool = true, build_
 
     # Sort builds to make this more deterministic
     for build in sort(info.builds; by=b->triplet(b.platform))
+        if !isa(build.artifact, JLLArtifactBinding)
+            throw(ArgumentError("Cannot generate a JLL for build '$(build.name)', whose products are bundled with Julia at '$(build.artifact.bundled_path)' rather than bound to an artifact!"))
+        end
+
         # Bind the main artifact
         bind_jll_artifact!(artifacts_toml_path, build.name, build.platform, build.artifact; lazy=build.lazy)
 

--- a/JLLGenerator.jl/test/runtests.jl
+++ b/JLLGenerator.jl/test/runtests.jl
@@ -408,6 +408,136 @@ end
     @test_throws ArgumentError make_on_load_callback(true)
 end
 
+@testset "Build binding shape" begin
+    binding = JLLArtifactBinding(treehash = "0c6c284985577758b3a339c6215c9d4e3d71420e",
+                                 download_sources = [])
+    mkbuild(; kwargs...) = JLLBuildInfo(; src_version = v"1.0.0",
+                                        platform = Platform("x86_64", "linux"),
+                                        name = "Demo",
+                                        products = [JLLLibraryProduct(:libz, "lib/libz.so.1", [])],
+                                        licenses = [mit_license], kwargs...)
+    roundtrip_build(b) = parse_toml_dict(JLLBuildInfo, generate_toml_dict(b))
+
+    # Anything we generate lives in an artifact, and its products' paths are
+    # relative to the artifact root
+    build = mkbuild(; artifact = binding)
+    @test build.artifact === binding
+    d = generate_toml_dict(build)
+    @test d["artifact"]["treehash"] == "sha1:0c6c284985577758b3a339c6215c9d4e3d71420e"
+    @test !haskey(d["artifact"], "bundled_path")
+    @test roundtrip_build(build) == build
+
+    # A hand-written record whose libraries ship inside Julia names the directory
+    # they ship in instead, in the same table
+    shlibdir_build = mkbuild()
+    @test shlibdir_build.artifact == JuliaBundledPath("private_shlibdir")
+    d = generate_toml_dict(shlibdir_build)
+    @test d["artifact"] == Dict("bundled_path" => "private_shlibdir")
+    @test roundtrip_build(shlibdir_build) == shlibdir_build
+
+    # Any Julia directory can be named, not just the shared library one
+    bindir_build = mkbuild(; artifact = JuliaBundledPath("private_bindir"))
+    @test generate_toml_dict(bindir_build)["artifact"]["bundled_path"] == "private_bindir"
+    @test roundtrip_build(bindir_build) == bindir_build
+
+    # `location` is gone: the table's own fields say which kind of binding it is,
+    # and a table that says both or neither says nothing we can act on
+    @test !any(haskey(generate_toml_dict(b), "location") for b in (build, shlibdir_build))
+    @test_throws ArgumentError JLLGenerator.parse_artifact_dict(
+        Dict("treehash" => "sha1:0c6c284985577758b3a339c6215c9d4e3d71420e",
+             "download_sources" => [], "bundled_path" => "private_shlibdir"))
+    @test_throws ArgumentError JLLGenerator.parse_artifact_dict(Dict("somewhere" => "else"))
+    @test_throws ArgumentError JLLGenerator.parse_artifact_dict(Dict{String,Any}())
+
+    # ... and a bundled build cannot be generated into a package, since
+    # there is nothing to bind into `Artifacts.toml`
+    jll = JLLInfo(; name = "Demo", version = v"1.0.0", builds = [shlibdir_build])
+    mktempdir() do dir
+        @test_throws ArgumentError generate_jll(dir, jll)
+    end
+
+    # A library entry must always state its path
+    @test_throws KeyError parse_toml_dict(JLLLibraryProduct,
+                        Dict("type" => "library", "name" => "libz", "soname" => "libz.so.1",
+                             "deps" => [], "flags" => String[]))
+end
+
+@testset "JLL.toml format marker" begin
+    jll = JLLInfo(; name = "Demo", version = v"1.0.0", builds = [
+        JLLBuildInfo(; src_version = v"1.0.0", platform = Platform("x86_64", "linux"),
+                     name = "Demo",
+                     artifact = JLLArtifactBinding(
+                        treehash = "0c6c284985577758b3a339c6215c9d4e3d71420e",
+                        download_sources = []),
+                     products = [JLLLibraryProduct(:libz, "lib/libz.so.1", [])],
+                     licenses = [mit_license])])
+    d = generate_toml_dict(jll)
+    # We are versioning the format published JLLs already speak, not declaring a new one
+    @test d["format_version"] == "1.0"
+    @test d["format_version"] isa String
+    @test parse_toml_dict(d) == jll
+
+    # A published record predates the marker, and must still read
+    legacy = copy(d); delete!(legacy, "format_version")
+    @test parse_toml_dict(legacy) == jll
+    # ... but a future major version has moved somewhere we cannot follow
+    future = copy(d); future["format_version"] = "2.0"
+    @test_throws ArgumentError parse_toml_dict(future)
+    nonsense = copy(d); nonsense["format_version"] = "not-a-version"
+    @test_throws ArgumentError parse_toml_dict(nonsense)
+
+    # A JLL with no static library asks for nothing newer than any released wrapper
+    mktempdir() do dir
+        generate_jll(dir, jll)
+        @test TOML.parsefile(joinpath(dir, "JLL.toml"))["format_version"] == "1.0"
+        @test TOML.parsefile(joinpath(dir, "Project.toml"))["compat"]["LazyJLLWrappers"] == "1.0.0"
+    end
+end
+
+@testset "Legacy v1 records" begin
+    # A record exactly as published JLLs write one today: no `format_version` and no
+    # `linkage`.  It must read, with sane defaults.
+    legacy = Dict{String,Any}(
+        "name" => "Legacy", "version" => "1.0.0", "julia_compat" => "1.6",
+        "platform_augmentation_code" => "",
+        "builds" => [Dict{String,Any}(
+            "name" => "Legacy", "platform" => "x86_64-linux-gnu", "deps" => [],
+            "lazy" => "false", "src_version" => "1.0.0", "sources" => [],
+            "callback_defs" => Dict(), "auxilliary_artifacts" => Dict(),
+            "licenses" => [Dict("filename" => "LICENSE.md", "license_text" => "x")],
+            "artifact" => Dict("treehash" => "sha1:0c6c284985577758b3a339c6215c9d4e3d71420e",
+                               "download_sources" => []),
+            "products" => [
+                Dict{String,Any}("type" => "library", "name" => "libz",
+                                 "path" => "lib/libz.so.1", "soname" => "libz.so.1",
+                                 "flags" => ["RTLD_LAZY"], "deps" => []),
+                Dict{String,Any}("type" => "executable", "name" => "tool", "path" => "bin/tool"),
+            ])])
+    info = parse_toml_dict(legacy)
+    build = only(info.builds)
+    # A build whose `artifact` table carries a treehash binds an artifact, whether or
+    # not the record ever said so in a `location`
+    @test build.artifact isa JLLArtifactBinding
+    @test string(build.artifact.treehash) == "sha1:0c6c284985577758b3a339c6215c9d4e3d71420e"
+    libz = only([p for p in build.products if isa(p, JLLLibraryProduct)])
+    # A library with no stated linkage is a shared library
+    @test libz.path == "lib/libz.so.1"
+    @test libz.soname == "libz.so.1"
+    # The executable comes back untouched
+    @test only([p for p in build.products if isa(p, JLLExecutableProduct)]).path == "bin/tool"
+
+    # No released generator ever wrote a record without an `artifact` table (the v1
+    # parser required the key), so absence is refused rather than defaulted
+    bundled = deepcopy(legacy)
+    delete!(only(bundled["builds"]), "artifact")
+    @test_throws KeyError parse_toml_dict(bundled)
+
+    # A stale `location` key is no longer read, and no longer stops a record parsing
+    stale = deepcopy(legacy)
+    only(stale["builds"])["location"] = "artifact"
+    @test only(parse_toml_dict(stale).builds).artifact isa JLLArtifactBinding
+end
+
 # Test that we can generate all of the stdlib JLLs in `contrib/`
 @testset "stdlib JLL generation" begin
     include(joinpath(dirname(@__DIR__), "contrib", "gen_julia_jlls.jl"))

--- a/LazyJLLWrappers.jl/src/GeneratorUtils.jl
+++ b/LazyJLLWrappers.jl/src/GeneratorUtils.jl
@@ -229,7 +229,7 @@ function init_footer(jb::JLLBlocks, build)
         if product["type"] == "executable"
             push!(jb.init_blocks, :(push!(PATH_list, $(path_var_name))))
         end
-        if product["type"] == "library"
+        if product["type"] == "library" && get(product, "linkage", "dynamic") == "dynamic"
             push!(jb.init_blocks, :(push!(LIBPATH_list, $(path_var_name))))
         end
     end

--- a/LazyJLLWrappers.jl/src/LazyJLLWrappers.jl
+++ b/LazyJLLWrappers.jl/src/LazyJLLWrappers.jl
@@ -90,6 +90,20 @@ include("FileProduct.jl")
 include("LibraryProduct.jl")
 include("Runtime.jl")
 
+function check_format_version(jll, toml_path)
+    if !haskey(jll, "format_version")
+        return v"1.0.0"
+    end
+    format = tryparse(VersionNumber, string(jll["format_version"]))
+    if format === nothing
+        error("`$(toml_path)` declares an invalid `format_version`")
+    end
+    if format.major != 1
+        error("`$(toml_path)` is a v$(format.major) JLL TOML manifest. This wrapper supports v1 only.")
+    end
+    return format
+end
+
 macro generate_jll_from_toml()
     # Lookup TOML location from this module
     toml_path = joinpath(pkgdir(__module__), "JLL.toml")
@@ -102,6 +116,7 @@ macro generate_jll_from_toml()
         toml_path = load_preference(__module__, "toml_path", toml_path)
     end
     jll = TOML.parsefile(toml_path)
+    check_format_version(jll, toml_path)
 
     # The `JLLBlocks` object is where we store up each of the pieces of code
     # that will constitute this JLL, including top-level statements, `__init__()`
@@ -145,7 +160,7 @@ macro generate_jll_from_toml()
     top_level_statements(jb, build, platform)
 
     # Sort our library products so that they are in dependency-order:
-    lib_products = [p for p in build["products"] if p["type"] == "library"]
+    is_dynamic_library(p) = (p["type"] == "library" && get(p, "linkage", "dynamic") == "dynamic")
     function calc_depths(lib_products)
         # We ignore external dependencies
         ignored = Set{String}()
@@ -174,6 +189,7 @@ macro generate_jll_from_toml()
         end
         return depths
     end
+    lib_products = filter(is_dynamic_library, build["products"])
     lib_depths = calc_depths(lib_products)
     function product_isless(p1, p2)
         if lib_depths[p1["name"]] != lib_depths[p2["name"]]


### PR DESCRIPTION
(below is human-written)

#### PR (schema) changes

This PR makes several (backwards-compatible) changes to the `JLL.toml` format to prepare for `static` libraries and adoption by pseudo-JLLs in Base. The schema changes are:
  1. Add a `linkage` field ("static" or "dynamic") to indicate whether this build product is a standard LibraryProduct or a StaticLibraryProduct (to be introduced in a follow-up PR)
  2. Enhance the `artifact` field to support describing Julia-bundled libraries for "pseudo-JLLs" (esp. `private_shlibdir`)
  3. Add a `format_version` field to mark future version / format changes (similar to `manifest_version` for `Manifest.toml`)

#### Motivation

This is in preparation for static linking support in JuliaC.jl. The plan is to piggyback on top of the `JLL.toml` files that BB2 generates to allow JuliaC to locate static variants of JLL libraries and link these statically (it also tells Julia to expose the `ccall` / `csymbol` calls to the native linker during the `--trim` build).

The main addl. requirements are:
 1. Static libraries need to be supported as first-class build products (and linked to their dynamic library counterparts)
 2. A stable notion of "library identity" needs to be maintained by Julia / `JLL.toml` to refer to / look up libraries.
 
 This PR tackles the `JLL.toml` schema changes required for (1). This is unused for now - a follow-up PR will tackle adding a proper `StaticLibraryProduct` etc. and using the new schema.

This commit was written with the assistance of generative AI (Claude) 🤖