### PR TITLE
LazyJLLWrappers: use `LazyLibraryPath` for lazy paths

### DIFF
--- a/LazyJLLWrappers.jl/Project.toml
+++ b/LazyJLLWrappers.jl/Project.toml
@@ -1,7 +1,7 @@
 name = "LazyJLLWrappers"
 uuid = "21706172-204c-4d4f-5420-656854206f44"
 authors = ["Elliot Saba"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/LazyJLLWrappers.jl/src/ExecutableProduct.jl
+++ b/LazyJLLWrappers.jl/src/ExecutableProduct.jl
@@ -37,6 +37,10 @@ end
 function executable_product_definition(jb::JLLBlocks, artifact, product)
     var_name, path_var_name, lazy_path_var_name = gen_lazy_artifact_path(jb, artifact, product)
 
+    # If we emitted in eager mode there is no lazy path object; use the `String`
+    # path global, which is filled in by the time the wrapper can be called.
+    path_ref = something(lazy_path_var_name, path_var_name)
+
     push!(jb.top_level_blocks, quote
         function $(var_name)(; adjust_PATH::Bool = true, adjust_LIBPATH::Bool = true)
             env = Base.invokelatest(
@@ -47,7 +51,7 @@ function executable_product_definition(jb::JLLBlocks, artifact, product)
                 adjust_PATH,
                 adjust_LIBPATH,
             )
-            return Cmd(Cmd([string($(lazy_path_var_name))]); env)
+            return Cmd(Cmd([string($(path_ref))]); env)
         end
     end)
 end

--- a/LazyJLLWrappers.jl/src/GeneratorUtils.jl
+++ b/LazyJLLWrappers.jl/src/GeneratorUtils.jl
@@ -180,6 +180,8 @@ function product_names(product)
     return var_name, path_var_name, lazy_path_var_name
 end
 
+use_lazy_libraries() = isdefined(Libdl, :LazyLibrary)
+
 function gen_lazy_artifact_path(jb::JLLBlocks, build, product)
     # The hashes in this TOML are `MultiHashParsing` hashes,
     # but we only support `sha1` hashes:
@@ -190,11 +192,24 @@ function gen_lazy_artifact_path(jb::JLLBlocks, build, product)
     treehash = Base.SHA1(treehash[6:end])
     var_name, path_var_name, lazy_path_var_name = product_names(product)
 
-    # Luckily, our `LazyArtifactPath` is generic enough that it can run on any Julia
-    # version that understands Artifacts (v1.3+) otherwise this would be a _huge_ pain.
+    if !use_lazy_libraries()
+        # Fully-eager regime: no lazy path object at all.  Every path variable
+        # is a plain `String`, resolved in `__init__()`.
+        path_expr = :(joinpath(artifact_path($(treehash)), $(product["path"])))
+        if VERSION >= v"1.6.0"
+            # An overriding preference substitutes the path outright
+            path_expr = load_preference(jb.mod, string(path_var_name), path_expr)
+        end
+        push!(jb.top_level_blocks, emit_typed_global(path_var_name, String, ""; isconst=false))
+        push!(jb.init_blocks, :(global $(path_var_name) = $(path_expr)))
+
+        # There is no lazy path object in this regime.
+        return var_name, path_var_name, nothing
+    end
+
     lazy_artifact_path = quote
-        LazyArtifactPath(
-            $(treehash),
+        Libdl.LazyLibraryPath(
+            LazyArtifactDir($(treehash)),
             $(product["path"]),
         )
     end
@@ -203,7 +218,7 @@ function gen_lazy_artifact_path(jb::JLLBlocks, build, product)
     if VERSION >= v"1.6.0"
         # This is some crazy dynamism; if we have a preference set, we
         # return a String pointing to the object, otherwise we return an `Expr`
-        # that defines the `LazyArtifactPath`, both of which can be interpolated
+        # that defines the `Libdl.LazyLibraryPath`, both of which can be interpolated
         # `jb.top_level_blocks` just fine.
         lazy_artifact_path = load_preference(
             jb.mod,

--- a/LazyJLLWrappers.jl/src/LazyJLLWrappers.jl
+++ b/LazyJLLWrappers.jl/src/LazyJLLWrappers.jl
@@ -1,6 +1,6 @@
 module LazyJLLWrappers
 
-export LazyArtifactPath, @generate_jll_from_toml
+export LazyArtifactDir, @generate_jll_from_toml
 using Libdl
 
 if VERSION >= v"1.6.0"
@@ -10,30 +10,15 @@ else
 end
 
 """
-    LazyArtifactPath
+    LazyArtifactDir
 
-Helper type that stores an artifact hash and a subpath, then lazily resolves it
-on-demand for e.g. `ccall()` and friends.  Caches its result so that lookup only
-happens once.
+Helper type that stores an artifact hash and supports conversion via `string`
+to the corresponding artifact directory.
 """
-struct LazyArtifactPath
+struct LazyArtifactDir
     artifact_hash::Base.SHA1
-    subpath::String
-    result::Ref{String}
-
-    function LazyArtifactPath(artifact_hash, subpath)
-        return new(artifact_hash, subpath, Ref{String}())
-    end
 end
-function Base.string(lap::LazyArtifactPath)
-    if !isassigned(lap.result)
-        lap.result[] = joinpath(
-            artifact_path(lap.artifact_hash),
-            lap.subpath,
-        )
-    end
-    return lap.result[]
-end
+Base.string(lad::LazyArtifactDir) = artifact_path(lad.artifact_hash)
 
 """
     JLLBlocks

--- a/LazyJLLWrappers.jl/src/LibraryProduct.jl
+++ b/LazyJLLWrappers.jl/src/LibraryProduct.jl
@@ -26,7 +26,7 @@ function library_product_definition(jb::JLLBlocks, artifact, product)
         end
     end
 
-    if isdefined(Libdl, :LazyLibrary)
+    if use_lazy_libraries()
         # On Julia v1.11+ we can use `LazyLibrary`
         push!(jb.top_level_blocks, emit_typed_global(
             var_name, LazyLibrary, quote

--- a/LazyJLLWrappers.jl/test/runtests.jl
+++ b/LazyJLLWrappers.jl/test/runtests.jl
@@ -141,8 +141,8 @@ example_jllinfos_path = joinpath(@__DIR__, "..", "..", "JLLGenerator.jl", "contr
     )
 end
 
-# Test that `LazyLirary` support works on Julias new enough to use it
-if isdefined(Libdl, :LazyLibrary)
+# Test that `LazyLibrary` support works on Julias new enough to use it
+if LazyJLLWrappers.use_lazy_libraries()
     @testset "Laziness" begin
         generate_and_load_jll(
             include(joinpath(example_jllinfos_path, "Ncurses_jll.jl")),
@@ -154,6 +154,18 @@ if isdefined(Libdl, :LazyLibrary)
             @test unsafe_string(ccall((:curses_version, libncurses), Cstring, ())) == "ncurses 6.4.20221231"
             @test !isempty(filter(l -> occursin("libncurses", l), Libdl.dllist()))
             @test isempty(filter(l -> occursin("libpanel", l), Libdl.dllist()))
+            """,
+        )
+    end
+
+    @testset "LazyLibrary path contract" begin
+        generate_and_load_jll(
+            include(joinpath(example_jllinfos_path, "libxls_jll.jl")),
+            """
+            import Libdl, LazyJLLWrappers
+            @test libxlsreader.path isa Union{String, Libdl.LazyLibraryPath}
+            @test libxlsreader.path.pieces[1] isa LazyJLLWrappers.LazyArtifactDir
+            @test unsafe_string(ccall((:xls_getVersion, libxlsreader), Cstring, ())) == "1.6.2"
             """,
         )
     end


### PR DESCRIPTION
Two fixes for the lazy / eager cases, both for trim support:
  1. Avoid `string(::LazyArtifactPath)` in `__init__` for non-lazy
     JLLs since this is not supported by trim for Julia <1.14
  2. Use `LazyLibraryPath` to opt-in to lazy path resolution for
     LazyLibrary JLLs, instead of a raw `LazyArtifactPath`.

(2) is technically required by the upstream documentation fwiw:
> `name`: Library name (or lazy path computation) as a `String`,
>  [`LazyLibraryPath`](@ref), or [`BundledLazyLibraryPath`](@ref).

but the real motivation is to standardize on whether the dynamism should be contained in `LazyLibrary.name` or `LazyLibraryPath.pieces` so that JuliaC.jl to knows where to add [a dedicated overload](https://github.com/JuliaLang/JuliaC.jl/blob/fe8306bb75e2bce69cc58b56f51672786566b546/src/scripts/juliac-trim-base.jl#L245-L247) for `--trim` support.

Drafted with minor assistance from Claude Fable 5 🤖 